### PR TITLE
libublk: switch to IoBuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ fn main() {
         .depth(depth)
         .nr_queues(2_u32)
         .ctrl_flags(libublk::sys::UBLK_F_USER_COPY)
-        .dev_flags(UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_ASYNC)
+        .dev_flags(UBLK_DEV_F_ADD_DEV)
         .build()
         .unwrap();
     let tgt_init = |dev: &mut UblkDev| {

--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -314,7 +314,7 @@ fn __test_add(
             .nr_queues(nr_queues)
             .depth(depth)
             .io_buf_bytes(buf_sz)
-            .dev_flags(UBLK_DEV_F_ADD_DEV | if aio { UBLK_DEV_F_ASYNC } else { 0 })
+            .dev_flags(UBLK_DEV_F_ADD_DEV)
             .build()
             .unwrap();
 

--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -355,8 +355,7 @@ fn __test_add(
         };
 
         let q_sync_fn = move |qid: u16, dev: &UblkDev| {
-            let q = UblkQueue::new(qid, dev).unwrap();
-            let bufs_rc = Rc::new(q.alloc_io_bufs(true));
+            let bufs_rc = Rc::new(dev.alloc_queue_io_bufs());
             let bufs = bufs_rc.clone();
             let lo_io_handler = move |q: &UblkQueue, tag: u16, io: &UblkIOCtx| {
                 let bufs = bufs_rc.clone();
@@ -364,7 +363,10 @@ fn __test_add(
                 lo_handle_io_cmd_sync(q, tag, io, bufs[tag as usize].as_mut_ptr());
             };
 
-            q.submit_fetch_commands(Some(&bufs))
+            UblkQueue::new(qid, dev)
+                .unwrap()
+                .regiser_io_bufs(Some(&bufs))
+                .submit_fetch_commands(Some(&bufs))
                 .wait_and_handle_io(lo_io_handler);
         };
 

--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -314,11 +314,7 @@ fn __test_add(
             .nr_queues(nr_queues)
             .depth(depth)
             .io_buf_bytes(buf_sz)
-            .dev_flags(
-                UBLK_DEV_F_ADD_DEV
-                    | UBLK_DEV_F_DONT_ALLOC_BUF
-                    | if aio { UBLK_DEV_F_ASYNC } else { 0 },
-            )
+            .dev_flags(UBLK_DEV_F_ADD_DEV | if aio { UBLK_DEV_F_ASYNC } else { 0 })
             .build()
             .unwrap();
 
@@ -352,7 +348,6 @@ fn __test_add(
                         };
                         cmd_op = sys::UBLK_IO_COMMIT_AND_FETCH_REQ;
                     }
-                    q.unregister_io_buf(tag);
                 }));
             }
             ublk_wait_and_handle_ios(&q_rc, &exe);

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -64,11 +64,7 @@ fn __test_add(
             .nr_queues(nr_queues)
             .io_buf_bytes(buf_size)
             .ctrl_flags(ctrl_flags)
-            .dev_flags(
-                UBLK_DEV_F_ADD_DEV
-                    | if aio { UBLK_DEV_F_ASYNC } else { 0 }
-                    | UBLK_DEV_F_DONT_ALLOC_BUF,
-            )
+            .dev_flags(UBLK_DEV_F_ADD_DEV | if aio { UBLK_DEV_F_ASYNC } else { 0 })
             .build()
             .unwrap();
         let tgt_init = |dev: &mut UblkDev| {
@@ -125,7 +121,6 @@ fn __test_add(
                         res = get_io_cmd_result(&q, tag);
                         cmd_op = libublk::sys::UBLK_IO_COMMIT_AND_FETCH_REQ;
                     }
-                    q.unregister_io_buf(tag);
                 }));
             }
             ublk_wait_and_handle_ios(&q_rc, &exe);

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -64,7 +64,7 @@ fn __test_add(
             .nr_queues(nr_queues)
             .io_buf_bytes(buf_size)
             .ctrl_flags(ctrl_flags)
-            .dev_flags(UBLK_DEV_F_ADD_DEV | if aio { UBLK_DEV_F_ASYNC } else { 0 })
+            .dev_flags(UBLK_DEV_F_ADD_DEV)
             .build()
             .unwrap();
         let tgt_init = |dev: &mut UblkDev| {

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -26,7 +26,9 @@ fn get_io_cmd_result(q: &UblkQueue, tag: u16) -> i32 {
 #[inline]
 fn handle_io_cmd(q: &UblkQueue, tag: u16) {
     let bytes = get_io_cmd_result(q, tag);
-    q.complete_io_cmd(tag, Ok(UblkIORes::Result(bytes)));
+    let buf_addr = q.get_io_buf_addr(tag);
+
+    q.complete_io_cmd(tag, buf_addr, Ok(UblkIORes::Result(bytes)));
 }
 
 fn test_add(id: i32, nr_queues: u32, depth: u32, ctrl_flags: u64, buf_size: u32, flags: NullFlags) {

--- a/examples/ramdisk.rs
+++ b/examples/ramdisk.rs
@@ -47,8 +47,7 @@ fn rd_add_dev(dev_id: i32, buf_addr: u64, size: u64, for_add: bool) {
         UBLK_DEV_F_ADD_DEV
     } else {
         UBLK_DEV_F_RECOVER_DEV
-    } | UBLK_DEV_F_ASYNC
-        | UBLK_DEV_F_DONT_ALLOC_BUF;
+    } | UBLK_DEV_F_ASYNC;
 
     let depth = 128_u16;
     let sess = libublk::UblkSessionBuilder::default()

--- a/examples/ramdisk.rs
+++ b/examples/ramdisk.rs
@@ -5,6 +5,7 @@ use io_uring::cqueue;
 /// UblkCtrl::start_dev_in_queue() and low level interface example.
 ///
 use libublk::dev_flags::*;
+use libublk::helpers::IoBuf;
 use libublk::io::{UblkDev, UblkQueue};
 use libublk::uring_async::ublk_wake_task;
 use libublk::{ctrl::UblkCtrl, UblkError};
@@ -75,7 +76,7 @@ fn rd_add_dev(dev_id: i32, buf_addr: u64, size: u64, for_add: bool) {
         let q = q_rc.clone();
         assert!(q.get_io_buf_addr(tag) == std::ptr::null_mut());
         f_vec.push(exe.spawn(async move {
-            let mut buffer: Vec<u8> = vec![0; buf_size];
+            let buffer = IoBuf::<u8>::new(buf_size);
             let addr = buffer.as_mut_ptr();
             let mut cmd_op = libublk::sys::UBLK_IO_FETCH_REQ;
             let mut res = 0;

--- a/examples/ramdisk.rs
+++ b/examples/ramdisk.rs
@@ -47,7 +47,7 @@ fn rd_add_dev(dev_id: i32, buf_addr: u64, size: u64, for_add: bool) {
         UBLK_DEV_F_ADD_DEV
     } else {
         UBLK_DEV_F_RECOVER_DEV
-    } | UBLK_DEV_F_ASYNC;
+    };
 
     let depth = 128_u16;
     let sess = libublk::UblkSessionBuilder::default()

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,97 @@
+use std::ops::{Deref, DerefMut};
+
+pub fn type_of_this<T>(_: &T) -> String {
+    std::any::type_name::<T>().to_string()
+}
+
+/// Slice like buffer, which address is aligned with 4096.
+///
+pub struct IoBuf<T> {
+    ptr: *mut T,
+    size: usize,
+}
+
+// Users of IoBuf has to deal with Send & Sync
+unsafe impl<T> Send for IoBuf<T> {}
+unsafe impl<T> Sync for IoBuf<T> {}
+
+impl<T> IoBuf<T> {
+    pub fn new(size: usize) -> Self {
+        let layout = std::alloc::Layout::from_size_align(size, 4096).unwrap();
+        let ptr = unsafe { std::alloc::alloc(layout) } as *mut T;
+
+        assert!(size != 0);
+
+        IoBuf { ptr, size }
+    }
+
+    /// how many elements in this buffer
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        let elem_size = core::mem::size_of::<T>();
+        self.size / elem_size
+    }
+
+    /// Return raw address of this buffer
+    pub fn as_ptr(&self) -> *const T {
+        self.ptr
+    }
+
+    /// Return mutable raw address of this buffer
+    pub fn as_mut_ptr(&self) -> *mut T {
+        self.ptr
+    }
+
+    /// fill zero for every bits of this buffer
+    pub fn zero_buf(&mut self) {
+        unsafe {
+            std::ptr::write_bytes(self.as_mut_ptr(), 0, self.len());
+        }
+    }
+}
+
+impl<T> std::fmt::Debug for IoBuf<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ptr {:?} size {} element type {}",
+            self.ptr,
+            self.size,
+            type_of_this(unsafe { &*self.ptr })
+        )
+    }
+}
+
+/// Slice reference of this buffer
+impl<T> Deref for IoBuf<T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        let elem_size = core::mem::size_of::<T>();
+        unsafe { std::slice::from_raw_parts(self.ptr, self.size / elem_size) }
+    }
+}
+
+/// Mutable slice reference of this buffer
+impl<T> DerefMut for IoBuf<T> {
+    fn deref_mut(&mut self) -> &mut [T] {
+        let elem_size = core::mem::size_of::<T>();
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.size / elem_size) }
+    }
+}
+
+/// Free buffer with same alloc layout
+impl<T> Drop for IoBuf<T> {
+    fn drop(&mut self) {
+        let layout = std::alloc::Layout::from_size_align(self.size, 4096).unwrap();
+        unsafe { std::alloc::dealloc(self.ptr as *mut u8, layout) };
+    }
+}
+
+#[macro_export]
+macro_rules! zero_io_buf {
+    ($buffer:expr) => {{
+        unsafe {
+            std::ptr::write_bytes($buffer.as_mut_ptr(), 0, $buffer.len());
+        }
+    }};
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,8 +365,9 @@ mod libublk {
             let io_handler = move |q: &UblkQueue, tag: u16, _io: &UblkIOCtx| {
                 let iod = q.get_iod(tag);
                 let bytes = (iod.nr_sectors << 9) as i32;
+                let buf_addr = q.get_io_buf_addr(tag);
 
-                q.complete_io_cmd(tag, Ok(UblkIORes::Result(bytes)));
+                q.complete_io_cmd(tag, buf_addr, Ok(UblkIORes::Result(bytes)));
             };
 
             UblkQueue::new(qid, _dev)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,16 +29,8 @@ pub mod dev_flags {
     /// use async/.await
     pub const UBLK_DEV_F_ASYNC: u32 = 1u32 << 3;
 
-    /// don't preallocate io buffer, target code has to allocate
-    /// IO buffer, and often work with ASYNC and UBLK_F_USER_COPY
-    /// together
-    pub const UBLK_DEV_F_DONT_ALLOC_BUF: u32 = 1u32 << 4;
-
-    pub const UBLK_DEV_F_ALL: u32 = UBLK_DEV_F_COMP_BATCH
-        | UBLK_DEV_F_ADD_DEV
-        | UBLK_DEV_F_RECOVER_DEV
-        | UBLK_DEV_F_ASYNC
-        | UBLK_DEV_F_DONT_ALLOC_BUF;
+    pub const UBLK_DEV_F_ALL: u32 =
+        UBLK_DEV_F_COMP_BATCH | UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_RECOVER_DEV | UBLK_DEV_F_ASYNC;
 }
 
 /// Ublk Fat completion result
@@ -352,7 +344,7 @@ mod libublk {
             .name("null")
             .depth(16_u32)
             .nr_queues(2_u32)
-            .dev_flags(UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_DONT_ALLOC_BUF)
+            .dev_flags(UBLK_DEV_F_ADD_DEV)
             .build()
             .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,9 +354,8 @@ mod libublk {
             Ok(0)
         };
         let (mut ctrl, dev) = sess.create_devices(tgt_init).unwrap();
-        let q_fn = move |qid: u16, _dev: &UblkDev| {
-            let q = UblkQueue::new(qid, _dev).unwrap();
-            let bufs_rc = Rc::new(q.alloc_io_bufs(true));
+        let q_fn = move |qid: u16, dev: &UblkDev| {
+            let bufs_rc = Rc::new(dev.alloc_queue_io_bufs());
             let bufs = bufs_rc.clone();
 
             let io_handler = move |q: &UblkQueue, tag: u16, _io: &UblkIOCtx| {
@@ -368,7 +367,10 @@ mod libublk {
                 q.complete_io_cmd(tag, buf_addr, Ok(UblkIORes::Result(bytes)));
             };
 
-            q.submit_fetch_commands(Some(&bufs))
+            UblkQueue::new(qid, dev)
+                .unwrap()
+                .regiser_io_bufs(Some(&bufs))
+                .submit_fetch_commands(Some(&bufs))
                 .wait_and_handle_io(io_handler);
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,11 +26,8 @@ pub mod dev_flags {
     /// tell UblkCtrl that we are recovering one old device
     pub const UBLK_DEV_F_RECOVER_DEV: u32 = 1u32 << 2;
 
-    /// use async/.await
-    pub const UBLK_DEV_F_ASYNC: u32 = 1u32 << 3;
-
     pub const UBLK_DEV_F_ALL: u32 =
-        UBLK_DEV_F_COMP_BATCH | UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_RECOVER_DEV | UBLK_DEV_F_ASYNC;
+        UBLK_DEV_F_COMP_BATCH | UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_RECOVER_DEV;
 }
 
 /// Ublk Fat completion result

--- a/src/uring_async.rs
+++ b/src/uring_async.rs
@@ -139,4 +139,5 @@ pub fn ublk_wait_and_handle_ios(q: &UblkQueue, exe: &smol::LocalExecutor) {
             _ => {}
         }
     }
+    q.unregister_io_bufs();
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -292,8 +292,8 @@ mod integration {
         }
 
         let size = 32_u64 << 20;
-        let buf = libublk::ublk_alloc_buf(size as usize, 4096);
-        let dev_addr = buf as u64;
+        let buf = libublk::helpers::IoBuf::<u8>::new(size as usize);
+        let dev_addr = buf.as_mut_ptr() as u64;
         let dev_flags = UBLK_DEV_F_ADD_DEV;
         let sess = libublk::UblkSessionBuilder::default()
             .name("ramdisk")
@@ -331,7 +331,6 @@ mod integration {
             __test_ublk_ramdisk(dev_id, dev_flags);
         })
         .unwrap();
-        libublk::ublk_dealloc_buf(buf, size as usize, 4096);
     }
 
     /// make FnMut closure for IO handling

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -98,10 +98,7 @@ mod integration {
                 .wait_and_handle_io(io_handler);
         }
 
-        __test_ublk_null(
-            UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_DONT_ALLOC_BUF,
-            null_handle_queue,
-        );
+        __test_ublk_null(UBLK_DEV_F_ADD_DEV, null_handle_queue);
     }
 
     /// make one ublk-null and test if /dev/ublkbN can be created successfully
@@ -127,7 +124,7 @@ mod integration {
         }
 
         __test_ublk_null(
-            UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_DONT_ALLOC_BUF | UBLK_DEV_F_COMP_BATCH,
+            UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_COMP_BATCH,
             null_handle_queue_batch,
         );
     }
@@ -153,7 +150,7 @@ mod integration {
         // submit one io_uring Nop via io-uring crate and UringOpFuture, and
         // user_data has to unique among io tasks, also has to encode tag
         // info, so please build user_data by UblkIOCtx::build_user_data_async()
-        let dev_flags = UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_ASYNC | UBLK_DEV_F_DONT_ALLOC_BUF;
+        let dev_flags = UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_ASYNC;
         let depth = 64_u16;
         let sess = libublk::UblkSessionBuilder::default()
             .name("null")
@@ -207,7 +204,6 @@ mod integration {
                             (*guard).done += 1;
                         }
                     }
-                    q.unregister_io_buf(tag);
                 }));
             }
 
@@ -298,7 +294,7 @@ mod integration {
         let size = 32_u64 << 20;
         let buf = libublk::ublk_alloc_buf(size as usize, 4096);
         let dev_addr = buf as u64;
-        let dev_flags = UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_DONT_ALLOC_BUF;
+        let dev_flags = UBLK_DEV_F_ADD_DEV;
         let sess = libublk::UblkSessionBuilder::default()
             .name("ramdisk")
             .id(-1)
@@ -364,10 +360,7 @@ mod integration {
                 .wait_and_handle_io(io_handler);
         }
 
-        __test_ublk_null(
-            UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_DONT_ALLOC_BUF,
-            null_queue_mut_io,
-        );
+        __test_ublk_null(UBLK_DEV_F_ADD_DEV, null_queue_mut_io);
     }
 
     /// run examples/ramdisk recovery test

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -309,9 +309,8 @@ mod integration {
         };
 
         let (mut ctrl, dev) = sess.create_devices(tgt_init).unwrap();
-        let q_fn = move |qid: u16, _dev: &UblkDev| {
-            let q = UblkQueue::new(qid, _dev).unwrap();
-            let bufs_rc = Rc::new(q.alloc_io_bufs(true));
+        let q_fn = move |qid: u16, dev: &UblkDev| {
+            let bufs_rc = Rc::new(dev.alloc_queue_io_bufs());
             let bufs = bufs_rc.clone();
 
             let io_handler = move |q: &UblkQueue, tag: u16, _io: &UblkIOCtx| {
@@ -321,7 +320,10 @@ mod integration {
                 rd_handle_io(q, tag, _io, buf_addr, dev_addr);
             };
 
-            q.submit_fetch_commands(Some(&bufs))
+            UblkQueue::new(qid, dev)
+                .unwrap()
+                .regiser_io_bufs(Some(&bufs))
+                .submit_fetch_commands(Some(&bufs))
                 .wait_and_handle_io(io_handler);
         };
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -150,7 +150,7 @@ mod integration {
         // submit one io_uring Nop via io-uring crate and UringOpFuture, and
         // user_data has to unique among io tasks, also has to encode tag
         // info, so please build user_data by UblkIOCtx::build_user_data_async()
-        let dev_flags = UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_ASYNC;
+        let dev_flags = UBLK_DEV_F_ADD_DEV;
         let depth = 64_u16;
         let sess = libublk::UblkSessionBuilder::default()
             .name("null")

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -86,8 +86,9 @@ mod integration {
             let io_handler = move |q: &UblkQueue, tag: u16, _io: &UblkIOCtx| {
                 let iod = q.get_iod(tag);
                 let bytes = (iod.nr_sectors << 9) as i32;
+                let buf_addr = std::ptr::null_mut();
 
-                q.complete_io_cmd(tag, Ok(UblkIORes::Result(bytes)));
+                q.complete_io_cmd(tag, buf_addr, Ok(UblkIORes::Result(bytes)));
             };
 
             UblkQueue::new(qid, _dev)
@@ -111,9 +112,10 @@ mod integration {
             let io_handler = move |q: &UblkQueue, tag: u16, _io: &UblkIOCtx| {
                 let iod = q.get_iod(tag);
                 let bytes = (iod.nr_sectors << 9) as i32;
+                let buf_addr = std::ptr::null_mut();
 
                 let res = Ok(UblkIORes::FatRes(UblkFatRes::BatchRes(vec![(tag, bytes)])));
-                q.complete_io_cmd(tag, res);
+                q.complete_io_cmd(tag, buf_addr, res);
             };
 
             UblkQueue::new(qid, _dev)
@@ -254,13 +256,13 @@ mod integration {
                     );
                 },
                 _ => {
-                    q.complete_io_cmd(tag, Err(UblkError::OtherError(-libc::EINVAL)));
+                    q.complete_io_cmd(tag, buf_addr, Err(UblkError::OtherError(-libc::EINVAL)));
                     return;
                 }
             }
 
             let res = Ok(UblkIORes::Result(bytes as i32));
-            q.complete_io_cmd(tag, res);
+            q.complete_io_cmd(tag, buf_addr, res);
         }
 
         fn __test_ublk_ramdisk(dev_id: i32) {
@@ -331,6 +333,7 @@ mod integration {
             let io_handler = move |q: &UblkQueue, tag: u16, _io: &UblkIOCtx| {
                 let iod = q.get_iod(tag);
                 let res = Ok(UblkIORes::Result((iod.nr_sectors << 9) as i32));
+                let buf_addr = std::ptr::null_mut();
 
                 {
                     q_vec.push(tag as i32);
@@ -339,7 +342,7 @@ mod integration {
                     }
                 }
 
-                q.complete_io_cmd(tag, res);
+                q.complete_io_cmd(tag, buf_addr, res);
             };
 
             UblkQueue::new(qid, _dev)


### PR DESCRIPTION

- add IoBuf definiiton
- apply IoBuf into libublk targets
-  move buffer management into target code completely
-  simply libublk
- target code becomes more readable now