### PR TITLE
Ctrl cmd async: support UblkCtrl::start_dev_async()

### DIFF
--- a/examples/ramdisk.rs
+++ b/examples/ramdisk.rs
@@ -102,7 +102,7 @@ fn start_dev_fn(
         let mut guard = res_clone.lock().unwrap();
         *guard = r.unwrap();
     });
-    ublk_run_ctrl_task(&ctrl_exe, &q_rc, &q_exe, &task);
+    ublk_run_ctrl_task(&ctrl_exe, &q_rc, &q_exe, &task).unwrap();
 
     let r = *res.lock().unwrap();
 
@@ -200,6 +200,10 @@ fn test_del() {
 }
 
 fn main() {
+    env_logger::builder()
+        .format_target(false)
+        .format_timestamp(None)
+        .init();
     if let Some(cmd) = std::env::args().nth(1) {
         match cmd.as_str() {
             "add" => test_add(0),

--- a/examples/ramdisk.rs
+++ b/examples/ramdisk.rs
@@ -118,10 +118,6 @@ fn rd_add_dev(dev_id: i32, buf_addr: *mut u8, size: u64, for_add: bool) {
     } else {
         eprintln!("device can't be started");
     }
-
-    //device may be deleted from another context, so it is normal
-    //to see -ENOENT failure here
-    let _ = ctrl.stop_dev();
 }
 
 fn rd_get_device_size(ctrl: &UblkCtrl) -> u64 {

--- a/src/ctrl.rs
+++ b/src/ctrl.rs
@@ -486,7 +486,7 @@ impl UblkCtrlInner {
 
     fn ublk_submit_cmd(
         &mut self,
-        data: &mut UblkCtrlCmdData,
+        data: &UblkCtrlCmdData,
         to_wait: usize,
     ) -> Result<u64, UblkError> {
         let fd = self.file.as_raw_fd();
@@ -541,7 +541,7 @@ impl UblkCtrlInner {
         let to_wait = 1;
 
         let old_buf = data.prep_un_privileged_dev_path(self);
-        let token = self.ublk_submit_cmd(&mut data, to_wait)?;
+        let token = self.ublk_submit_cmd(&data, to_wait)?;
         let res = self.poll_cmd(token);
 
         data.unprep_un_privileged_dev_path(self, old_buf);

--- a/src/ctrl.rs
+++ b/src/ctrl.rs
@@ -484,7 +484,7 @@ impl UblkCtrlInner {
             .user_data(token as u64)
     }
 
-    fn ublk_submit_ctrl_cmd(
+    fn ublk_submit_cmd(
         &mut self,
         data: &mut UblkCtrlCmdData,
         to_wait: usize,
@@ -541,7 +541,7 @@ impl UblkCtrlInner {
         let to_wait = 1;
 
         let old_buf = data.prep_un_privileged_dev_path(self);
-        let token = self.ublk_submit_ctrl_cmd(&mut data, to_wait)?;
+        let token = self.ublk_submit_cmd(&mut data, to_wait)?;
         let res = self.poll_cmd(token);
 
         data.unprep_un_privileged_dev_path(self, old_buf);
@@ -1229,7 +1229,7 @@ impl UblkCtrl {
         ctrl.prep_start_dev(dev)?;
 
         let old_buf = data.prep_un_privileged_dev_path(&ctrl);
-        let token = ctrl.ublk_submit_ctrl_cmd(&mut data, 0)?;
+        let token = ctrl.ublk_submit_cmd(&mut data, 0)?;
 
         Ok((token, (old_buf as *mut u8, CTRL_UBLKC_PATH_MAX, 8)))
     }

--- a/src/ctrl.rs
+++ b/src/ctrl.rs
@@ -530,11 +530,8 @@ impl UblkCtrlInner {
         Ok(token)
     }
 
-    /// Poll one control command until it is completed
+    /// check one control command and see if it is completed
     ///
-    /// Note: so far, we only support to poll at most one-inflight
-    /// command, and the use case is for supporting to run start_dev
-    /// in queue io handling context
     fn poll_cmd(&mut self, token: u64) -> Result<i32, UblkError> {
         CTRL_URING.with(|refcell| {
             let mut r = refcell.borrow_mut();
@@ -993,10 +990,10 @@ impl UblkCtrl {
         self.get_inner().dev_info
     }
 
-    // Return ublk_driver's features
-    //
-    // Target code may need to query driver features runtime, so
-    // cache it inside device
+    /// Return ublk_driver's features
+    ///
+    /// Target code may need to query driver features runtime, so
+    /// cache it inside device
     pub fn get_driver_features(&self) -> Option<u64> {
         self.get_inner().features
     }
@@ -1056,10 +1053,10 @@ impl UblkCtrl {
         }
     }
 
-    // Return target json data
-    //
-    // Should only be called after device is started, otherwise target data
-    // won't be serialized out, and this API returns None
+    /// Return target json data
+    ///
+    /// Should only be called after device is started, otherwise target data
+    /// won't be serialized out, and this API returns None
     pub fn get_target_data_from_json(&self) -> Option<serde_json::Value> {
         let val = &self.get_inner().json["target_data"];
         if !val.is_null() {
@@ -1405,7 +1402,7 @@ impl UblkCtrl {
         Ok(0)
     }
 
-    // iterator over each ublk device ID
+    /// Iterator over each ublk device ID
     pub fn for_each_dev_id<T>(ops: T)
     where
         T: Fn(u32) + Clone + 'static,

--- a/src/ctrl.rs
+++ b/src/ctrl.rs
@@ -6,7 +6,7 @@ use derive_setters::*;
 use io_uring::{cqueue, opcode, squeue, types, IoUring};
 use log::{error, trace};
 use serde::Deserialize;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::AsRawFd;
 use std::sync::{Arc, RwLock};
 use std::{
     fs,
@@ -254,12 +254,6 @@ struct UblkCtrlInner {
     queue_tids: Vec<i32>,
     nr_queues_configured: u16,
     ring: IoUring<squeue::Entry128>,
-}
-
-impl AsRawFd for UblkCtrl {
-    fn as_raw_fd(&self) -> RawFd {
-        self.get_inner_mut().ring.as_raw_fd()
-    }
 }
 
 impl Drop for UblkCtrlInner {

--- a/src/io.rs
+++ b/src/io.rs
@@ -7,7 +7,7 @@ use io_uring::{cqueue, opcode, squeue, types, IoUring};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::fs;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 
 /// UblkIOCtx
 ///
@@ -431,6 +431,12 @@ pub struct UblkQueue<'a> {
     /// uring is shared for handling target IO, so has to be
     /// public
     pub q_ring: RefCell<IoUring<squeue::Entry>>,
+}
+
+impl AsRawFd for UblkQueue<'_> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.q_ring.borrow().as_raw_fd()
+    }
 }
 
 impl Drop for UblkQueue<'_> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 //! `<https://github.com/ming1/ubdsrv/blob/master/doc/ublk_intro.pdf>`
 
 use log::error;
-use std::alloc::{alloc, dealloc, Layout};
 
 pub mod ctrl;
 pub mod helpers;
@@ -88,22 +87,6 @@ pub enum UblkError {
 
     #[error("other failure")]
     OtherError(i32),
-}
-
-pub fn ublk_alloc_buf(size: usize, align: usize) -> *mut u8 {
-    let layout = match Layout::from_size_align(size, align) {
-        Ok(r) => r,
-        Err(_) => return std::ptr::null_mut(),
-    };
-    unsafe { alloc(layout) }
-}
-
-pub fn ublk_dealloc_buf(ptr: *mut u8, size: usize, align: usize) {
-    let layout = match Layout::from_size_align(size, align) {
-        Ok(r) => r,
-        Err(_) => return,
-    };
-    unsafe { dealloc(ptr as *mut u8, layout) };
 }
 
 #[cfg(test)]


### PR DESCRIPTION

- Add UblkCtrl::start_dev_async(), so ublk control device starts to support async/.await

- improve ublk_run_ctrl_tasks() by polling on ctrl & queue io_urings, so
random delay is avoided

- basically it is ready to support to creating multiple device in single context