### PR TITLE
Rust cleanup error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ env_logger = "0.9"
 smol = "1.3.0"
 slab = "0.4.9"
 derive_setters = "0.1"
+bitflags = "2.4.1"
 
 [dev-dependencies]
 block-utils = "0.11.0"
@@ -59,4 +60,3 @@ ilog = "1.0.1"
 async-std = {version = "1.12.0"}
 ctrlc = "3.4.0"
 daemonize = "0.5"
-bitflags = "2.4.1"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ fn main() {
         UblkCtrlBuilder::default()
             .name("async_null")
             .nr_queues(2)
-            .dev_flags(libublk::dev_flags::UBLK_DEV_F_ADD_DEV)
+            .dev_flags(libublk::UblkFlags::UBLK_DEV_F_ADD_DEV)
             .build()
             .unwrap(),
     );

--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -483,10 +483,10 @@ fn main() {
                 .unwrap()
                 .parse::<i32>()
                 .unwrap_or(-1);
-            UblkCtrl::new_simple(id, 0).unwrap().del_dev().unwrap();
+            UblkCtrl::new_simple(id).unwrap().del_dev().unwrap();
         }
         Some(("list", _add_matches)) => UblkCtrl::for_each_dev_id(|dev_id| {
-            UblkCtrl::new_simple(dev_id as i32, 0).unwrap().dump();
+            UblkCtrl::new_simple(dev_id as i32).unwrap().dump();
         }),
         _ => {
             println!("unsupported command");

--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -206,17 +206,111 @@ fn lo_handle_io_cmd_sync(q: &UblkQueue<'_>, tag: u16, i: &UblkIOCtx, buf_addr: *
     }
 }
 
-fn test_add(
+fn q_fn(qid: u16, dev: &UblkDev) {
+    let bufs_rc = Rc::new(dev.alloc_queue_io_bufs());
+    let bufs = bufs_rc.clone();
+    let lo_io_handler = move |q: &UblkQueue, tag: u16, io: &UblkIOCtx| {
+        let bufs = bufs_rc.clone();
+
+        lo_handle_io_cmd_sync(q, tag, io, bufs[tag as usize].as_mut_ptr());
+    };
+
+    UblkQueue::new(qid, dev)
+        .unwrap()
+        .regiser_io_bufs(Some(&bufs))
+        .submit_fetch_commands(Some(&bufs))
+        .wait_and_handle_io(lo_io_handler);
+}
+
+fn q_a_fn(qid: u16, dev: &UblkDev, depth: u16) {
+    let q_rc = Rc::new(UblkQueue::new(qid as u16, &dev).unwrap());
+    let exe = smol::LocalExecutor::new();
+    let mut f_vec = Vec::new();
+
+    for tag in 0..depth {
+        let q = q_rc.clone();
+
+        f_vec.push(exe.spawn(async move {
+            let buf = IoBuf::<u8>::new(q.dev.dev_info.max_io_buf_bytes as usize);
+            let buf_addr = buf.as_mut_ptr();
+            let mut cmd_op = sys::UBLK_U_IO_FETCH_REQ;
+            let mut res = 0;
+
+            q.register_io_buf(tag, &buf);
+            loop {
+                let cmd_res = q.submit_io_cmd(tag, cmd_op, buf_addr, res).await;
+                if cmd_res == sys::UBLK_IO_RES_ABORT {
+                    break;
+                }
+
+                res = lo_handle_io_cmd_async(&q, tag, buf_addr).await;
+                cmd_op = sys::UBLK_U_IO_COMMIT_AND_FETCH_REQ;
+            }
+        }));
+    }
+    ublk_wait_and_handle_ios(&q_rc, &exe);
+    smol::block_on(async { futures::future::join_all(f_vec).await });
+}
+
+fn __loop_add(
     id: i32,
     nr_queues: u32,
-    depth: u32,
+    depth: u16,
+    buf_sz: u32,
+    backing_file: &String,
+    ctrl_flags: u64,
+    lo_flags: LoFlags,
+) {
+    let aio = lo_flags.intersects(LoFlags::ASYNC);
+    let oneshot = lo_flags.intersects(LoFlags::ONESHOT);
+    // LooTgt has to live in the whole device lifetime
+    let lo = LoopTgt {
+        back_file: std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&backing_file)
+            .unwrap(),
+        direct_io: 1,
+        back_file_path: backing_file.clone(),
+    };
+    let ctrl = libublk::ctrl::UblkCtrlBuilder::default()
+        .name("example_loop")
+        .id(id)
+        .ctrl_flags(ctrl_flags)
+        .nr_queues(nr_queues.try_into().unwrap())
+        .depth(depth)
+        .io_buf_bytes(buf_sz)
+        .dev_flags(UblkFlags::UBLK_DEV_F_ADD_DEV)
+        .build()
+        .unwrap();
+    let tgt_init = |dev: &mut UblkDev| lo_init_tgt(dev, &lo);
+    let wh = move |d_ctrl: &UblkCtrl| {
+        d_ctrl.dump();
+        if oneshot {
+            d_ctrl.kill_dev().unwrap();
+        }
+    };
+
+    if aio {
+        ctrl.run_target(tgt_init, move |qid, dev: &_| q_a_fn(qid, dev, depth), wh)
+            .unwrap();
+    } else {
+        ctrl.run_target(tgt_init, move |qid, dev: &_| q_fn(qid, dev), wh)
+            .unwrap();
+    }
+}
+
+fn loop_add(
+    id: i32,
+    nr_queues: u32,
+    depth: u16,
     buf_sz: u32,
     backing_file: &String,
     ctrl_flags: u64,
     lo_flags: LoFlags,
 ) {
     if lo_flags.intersects(LoFlags::FOREGROUND) {
-        __test_add(
+        __loop_add(
             id,
             nr_queues,
             depth,
@@ -231,7 +325,7 @@ fn test_add(
             .stderr(daemonize::Stdio::keep());
 
         match daemonize.start() {
-            Ok(_) => __test_add(
+            Ok(_) => __loop_add(
                 id,
                 nr_queues,
                 depth,
@@ -241,100 +335,6 @@ fn test_add(
                 lo_flags,
             ),
             Err(_) => panic!(),
-        }
-    }
-}
-
-fn __test_add(
-    id: i32,
-    nr_queues: u32,
-    depth: u32,
-    buf_sz: u32,
-    backing_file: &String,
-    ctrl_flags: u64,
-    lo_flags: LoFlags,
-) {
-    let aio = lo_flags.intersects(LoFlags::ASYNC);
-    let oneshot = lo_flags.intersects(LoFlags::ONESHOT);
-    {
-        // LooTgt has to live in the whole device lifetime
-        let lo = LoopTgt {
-            back_file: std::fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(&backing_file)
-                .unwrap(),
-            direct_io: 1,
-            back_file_path: backing_file.clone(),
-        };
-        let ctrl = libublk::ctrl::UblkCtrlBuilder::default()
-            .name("example_loop")
-            .id(id)
-            .ctrl_flags(ctrl_flags)
-            .nr_queues(nr_queues.try_into().unwrap())
-            .depth(depth.try_into().unwrap())
-            .io_buf_bytes(buf_sz)
-            .dev_flags(UblkFlags::UBLK_DEV_F_ADD_DEV)
-            .build()
-            .unwrap();
-
-        let tgt_init = |dev: &mut UblkDev| lo_init_tgt(dev, &lo);
-        let q_async_fn = move |qid: u16, dev: &UblkDev| {
-            let q_rc = Rc::new(UblkQueue::new(qid as u16, &dev).unwrap());
-            let exe = smol::LocalExecutor::new();
-            let mut f_vec = Vec::new();
-
-            for tag in 0..depth as u16 {
-                let q = q_rc.clone();
-
-                f_vec.push(exe.spawn(async move {
-                    let buf = IoBuf::<u8>::new(q.dev.dev_info.max_io_buf_bytes as usize);
-                    let buf_addr = buf.as_mut_ptr();
-                    let mut cmd_op = sys::UBLK_U_IO_FETCH_REQ;
-                    let mut res = 0;
-
-                    q.register_io_buf(tag, &buf);
-                    loop {
-                        let cmd_res = q.submit_io_cmd(tag, cmd_op, buf_addr, res).await;
-                        if cmd_res == sys::UBLK_IO_RES_ABORT {
-                            break;
-                        }
-
-                        res = lo_handle_io_cmd_async(&q, tag, buf_addr).await;
-                        cmd_op = sys::UBLK_U_IO_COMMIT_AND_FETCH_REQ;
-                    }
-                }));
-            }
-            ublk_wait_and_handle_ios(&q_rc, &exe);
-            smol::block_on(async { futures::future::join_all(f_vec).await });
-        };
-
-        let q_sync_fn = move |qid: u16, dev: &UblkDev| {
-            let bufs_rc = Rc::new(dev.alloc_queue_io_bufs());
-            let bufs = bufs_rc.clone();
-            let lo_io_handler = move |q: &UblkQueue, tag: u16, io: &UblkIOCtx| {
-                let bufs = bufs_rc.clone();
-
-                lo_handle_io_cmd_sync(q, tag, io, bufs[tag as usize].as_mut_ptr());
-            };
-
-            UblkQueue::new(qid, dev)
-                .unwrap()
-                .regiser_io_bufs(Some(&bufs))
-                .submit_fetch_commands(Some(&bufs))
-                .wait_and_handle_io(lo_io_handler);
-        };
-
-        let wh = move |d_ctrl: &UblkCtrl| {
-            d_ctrl.dump();
-            if oneshot {
-                d_ctrl.kill_dev().unwrap();
-            }
-        };
-        if aio {
-            ctrl.run_target(tgt_init, q_async_fn, wh).unwrap();
-        } else {
-            ctrl.run_target(tgt_init, q_sync_fn, wh).unwrap();
         }
     }
 }
@@ -466,10 +466,10 @@ fn main() {
             } else {
                 0
             };
-            test_add(
+            loop_add(
                 id,
                 nr_queues,
-                depth,
+                depth.try_into().unwrap(),
                 buf_size,
                 backing_file,
                 ctrl_flags,

--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -3,11 +3,10 @@ use bitflags::bitflags;
 use clap::{Arg, ArgAction, Command};
 use ilog::IntLog;
 use io_uring::{opcode, squeue, types};
-use libublk::dev_flags::*;
 use libublk::helpers::IoBuf;
 use libublk::io::{UblkDev, UblkIOCtx, UblkQueue};
 use libublk::uring_async::ublk_wait_and_handle_ios;
-use libublk::{ctrl::UblkCtrl, sys, UblkError, UblkIORes};
+use libublk::{ctrl::UblkCtrl, sys, UblkError, UblkFlags, UblkIORes};
 use log::trace;
 use serde::Serialize;
 use std::os::unix::fs::FileTypeExt;
@@ -275,7 +274,7 @@ fn __test_add(
             .nr_queues(nr_queues.try_into().unwrap())
             .depth(depth.try_into().unwrap())
             .io_buf_bytes(buf_sz)
-            .dev_flags(UBLK_DEV_F_ADD_DEV)
+            .dev_flags(UblkFlags::UBLK_DEV_F_ADD_DEV)
             .build()
             .unwrap();
 

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -281,10 +281,10 @@ fn main() {
                 .unwrap()
                 .parse::<i32>()
                 .unwrap_or(-1);
-            UblkCtrl::new_simple(id, 0).unwrap().del_dev().unwrap();
+            UblkCtrl::new_simple(id).unwrap().del_dev().unwrap();
         }
         Some(("list", _add_matches)) => UblkCtrl::for_each_dev_id(|dev_id| {
-            UblkCtrl::new_simple(dev_id as i32, 0).unwrap().dump();
+            UblkCtrl::new_simple(dev_id as i32).unwrap().dump();
         }),
         _ => {
             println!("unsupported command");

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -1,10 +1,9 @@
 use bitflags::bitflags;
 use clap::{Arg, ArgAction, Command};
-use libublk::dev_flags::*;
 use libublk::helpers::IoBuf;
 use libublk::io::{UblkDev, UblkIOCtx, UblkQueue};
 use libublk::uring_async::ublk_wait_and_handle_ios;
-use libublk::{ctrl::UblkCtrl, UblkIORes};
+use libublk::{ctrl::UblkCtrl, UblkFlags, UblkIORes};
 use std::rc::Rc;
 
 bitflags! {
@@ -64,7 +63,7 @@ fn __test_add(
             .nr_queues(nr_queues.try_into().unwrap())
             .io_buf_bytes(buf_size)
             .ctrl_flags(ctrl_flags)
-            .dev_flags(UBLK_DEV_F_ADD_DEV)
+            .dev_flags(UblkFlags::UBLK_DEV_F_ADD_DEV)
             .build()
             .unwrap();
         let tgt_init = |dev: &mut UblkDev| {

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -30,22 +30,62 @@ fn handle_io_cmd(q: &UblkQueue, tag: u16, buf_addr: *mut u8) {
     q.complete_io_cmd(tag, buf_addr, Ok(UblkIORes::Result(bytes)));
 }
 
-fn test_add(id: i32, nr_queues: u32, depth: u32, ctrl_flags: u64, buf_size: u32, flags: NullFlags) {
-    if flags.intersects(NullFlags::FOREGROUND) {
-        __test_add(id, nr_queues, depth, ctrl_flags, buf_size, flags);
-    } else {
-        let daemonize = daemonize::Daemonize::new()
-            .stdout(daemonize::Stdio::keep())
-            .stderr(daemonize::Stdio::keep());
+fn q_sync_fn(qid: u16, dev: &UblkDev, user_copy: bool) {
+    let bufs_rc = Rc::new(dev.alloc_queue_io_bufs());
+    let bufs = bufs_rc.clone();
 
-        match daemonize.start() {
-            Ok(_) => __test_add(id, nr_queues, depth, ctrl_flags, buf_size, flags),
-            _ => panic!(),
-        }
-    }
+    // logic for io handling
+    let io_handler = move |q: &UblkQueue, tag: u16, _io: &UblkIOCtx| {
+        let buf_addr = if user_copy {
+            std::ptr::null_mut()
+        } else {
+            bufs[tag as usize].as_mut_ptr()
+        };
+        handle_io_cmd(q, tag, buf_addr);
+    };
+
+    UblkQueue::new(qid, dev)
+        .unwrap()
+        .regiser_io_bufs(if user_copy { None } else { Some(&bufs_rc) })
+        .submit_fetch_commands(if user_copy { None } else { Some(&bufs_rc) })
+        .wait_and_handle_io(io_handler);
 }
 
-fn __test_add(
+fn q_async_fn(qid: u16, dev: &UblkDev, user_copy: bool) {
+    let q_rc = Rc::new(UblkQueue::new(qid as u16, &dev).unwrap());
+    let exe = smol::LocalExecutor::new();
+    let mut f_vec = Vec::new();
+
+    for tag in 0..dev.dev_info.queue_depth as u16 {
+        let q = q_rc.clone();
+
+        f_vec.push(exe.spawn(async move {
+            let buf = IoBuf::<u8>::new(q.dev.dev_info.max_io_buf_bytes as usize);
+            let mut cmd_op = libublk::sys::UBLK_U_IO_FETCH_REQ;
+            let mut res = 0;
+            let buf_addr = if user_copy {
+                std::ptr::null_mut()
+            } else {
+                buf.as_mut_ptr()
+            };
+
+            q.register_io_buf(tag, &buf);
+            loop {
+                let cmd_res = q.submit_io_cmd(tag, cmd_op, buf_addr, res).await;
+                if cmd_res == libublk::sys::UBLK_IO_RES_ABORT {
+                    break;
+                }
+
+                res = get_io_cmd_result(&q, tag);
+                cmd_op = libublk::sys::UBLK_U_IO_COMMIT_AND_FETCH_REQ;
+            }
+        }));
+    }
+    ublk_wait_and_handle_ios(&q_rc, &exe);
+    smol::block_on(async { futures::future::join_all(f_vec).await });
+}
+
+fn __null_add(
     id: i32,
     nr_queues: u32,
     depth: u32,
@@ -55,89 +95,49 @@ fn __test_add(
 ) {
     let aio = flags.intersects(NullFlags::ASYNC);
     let oneshot = flags.intersects(NullFlags::ONESHOT);
-    {
-        let ctrl = libublk::ctrl::UblkCtrlBuilder::default()
-            .name("example_null")
-            .id(id)
-            .depth(depth.try_into().unwrap())
-            .nr_queues(nr_queues.try_into().unwrap())
-            .io_buf_bytes(buf_size)
-            .ctrl_flags(ctrl_flags)
-            .dev_flags(UblkFlags::UBLK_DEV_F_ADD_DEV)
-            .build()
-            .unwrap();
-        let tgt_init = |dev: &mut UblkDev| {
-            dev.set_default_params(250_u64 << 30);
-            Ok(0)
-        };
-        let user_copy = (ctrl.dev_info().flags & libublk::sys::UBLK_F_USER_COPY as u64) != 0;
-        // queue level logic
-        let q_sync_handler = move |qid: u16, dev: &UblkDev| {
-            let bufs_rc = Rc::new(dev.alloc_queue_io_bufs());
-            let bufs = bufs_rc.clone();
+    let ctrl = libublk::ctrl::UblkCtrlBuilder::default()
+        .name("example_null")
+        .id(id)
+        .depth(depth.try_into().unwrap())
+        .nr_queues(nr_queues.try_into().unwrap())
+        .io_buf_bytes(buf_size)
+        .ctrl_flags(ctrl_flags)
+        .dev_flags(UblkFlags::UBLK_DEV_F_ADD_DEV)
+        .build()
+        .unwrap();
+    let tgt_init = |dev: &mut UblkDev| {
+        dev.set_default_params(250_u64 << 30);
+        Ok(0)
+    };
+    let user_copy = (ctrl.dev_info().flags & libublk::sys::UBLK_F_USER_COPY as u64) != 0;
+    let wh = move |d_ctrl: &UblkCtrl| {
+        d_ctrl.dump();
+        if oneshot {
+            d_ctrl.kill_dev().unwrap();
+        }
+    };
 
-            // logic for io handling
-            let io_handler = move |q: &UblkQueue, tag: u16, _io: &UblkIOCtx| {
-                let buf_addr = if user_copy {
-                    std::ptr::null_mut()
-                } else {
-                    bufs[tag as usize].as_mut_ptr()
-                };
-                handle_io_cmd(q, tag, buf_addr);
-            };
+    // Now start this ublk target
+    if aio {
+        let q_async_handler = move |qid, dev: &_| q_async_fn(qid, dev, user_copy);
+        ctrl.run_target(tgt_init, q_async_handler, wh).unwrap();
+    } else {
+        let q_sync_handler = move |qid, dev: &_| q_sync_fn(qid, dev, user_copy);
+        ctrl.run_target(tgt_init, q_sync_handler, wh).unwrap();
+    }
+}
 
-            UblkQueue::new(qid, dev)
-                .unwrap()
-                .regiser_io_bufs(if user_copy { None } else { Some(&bufs_rc) })
-                .submit_fetch_commands(if user_copy { None } else { Some(&bufs_rc) })
-                .wait_and_handle_io(io_handler);
-        };
-        let q_async_handler = move |qid: u16, dev: &UblkDev| {
-            let q_rc = Rc::new(UblkQueue::new(qid as u16, &dev).unwrap());
-            let exe = smol::LocalExecutor::new();
-            let mut f_vec = Vec::new();
+fn null_add(id: i32, nr_queues: u32, depth: u32, ctrl_flags: u64, buf_size: u32, flags: NullFlags) {
+    if flags.intersects(NullFlags::FOREGROUND) {
+        __null_add(id, nr_queues, depth, ctrl_flags, buf_size, flags);
+    } else {
+        let daemonize = daemonize::Daemonize::new()
+            .stdout(daemonize::Stdio::keep())
+            .stderr(daemonize::Stdio::keep());
 
-            for tag in 0..depth as u16 {
-                let q = q_rc.clone();
-
-                f_vec.push(exe.spawn(async move {
-                    let buf = IoBuf::<u8>::new(q.dev.dev_info.max_io_buf_bytes as usize);
-                    let mut cmd_op = libublk::sys::UBLK_U_IO_FETCH_REQ;
-                    let mut res = 0;
-                    let buf_addr = if user_copy {
-                        std::ptr::null_mut()
-                    } else {
-                        buf.as_mut_ptr()
-                    };
-
-                    q.register_io_buf(tag, &buf);
-                    loop {
-                        let cmd_res = q.submit_io_cmd(tag, cmd_op, buf_addr, res).await;
-                        if cmd_res == libublk::sys::UBLK_IO_RES_ABORT {
-                            break;
-                        }
-
-                        res = get_io_cmd_result(&q, tag);
-                        cmd_op = libublk::sys::UBLK_U_IO_COMMIT_AND_FETCH_REQ;
-                    }
-                }));
-            }
-            ublk_wait_and_handle_ios(&q_rc, &exe);
-            smol::block_on(async { futures::future::join_all(f_vec).await });
-        };
-
-        let wh = move |d_ctrl: &UblkCtrl| {
-            d_ctrl.dump();
-            if oneshot {
-                d_ctrl.kill_dev().unwrap();
-            }
-        };
-
-        // Now start this ublk target
-        if aio {
-            ctrl.run_target(tgt_init, q_async_handler, wh).unwrap();
-        } else {
-            ctrl.run_target(tgt_init, q_sync_handler, wh).unwrap();
+        match daemonize.start() {
+            Ok(_) => __null_add(id, nr_queues, depth, ctrl_flags, buf_size, flags),
+            _ => panic!(),
         }
     }
 }
@@ -272,7 +272,7 @@ fn main() {
                 0
             };
 
-            test_add(id, nr_queues, depth, ctrl_flags, buf_size, flags);
+            null_add(id, nr_queues, depth, ctrl_flags, buf_size, flags);
         }
         Some(("del", add_matches)) => {
             let id = add_matches

--- a/examples/ramdisk.rs
+++ b/examples/ramdisk.rs
@@ -178,7 +178,7 @@ fn test_add(recover: usize) {
 
             if recover > 0 {
                 assert!(dev_id >= 0);
-                let ctrl = UblkCtrl::new_simple(dev_id, 0).unwrap();
+                let ctrl = UblkCtrl::new_simple(dev_id).unwrap();
                 size = rd_get_device_size(&ctrl);
 
                 ctrl.start_user_recover().unwrap();
@@ -194,7 +194,7 @@ fn test_add(recover: usize) {
 fn test_del() {
     let s = std::env::args().nth(2).unwrap_or_else(|| "0".to_string());
     let dev_id = s.parse::<i32>().unwrap();
-    let ctrl = UblkCtrl::new_simple(dev_id as i32, 0).unwrap();
+    let ctrl = UblkCtrl::new_simple(dev_id as i32).unwrap();
 
     ctrl.del_dev().unwrap();
 }

--- a/examples/ramdisk.rs
+++ b/examples/ramdisk.rs
@@ -4,10 +4,10 @@ use libublk::ctrl::UblkCtrl;
 /// Serves for covering recovery test[`test_ublk_ramdisk_recovery`],
 /// UblkCtrl::start_dev_in_queue() and low level interface example.
 ///
-use libublk::dev_flags::*;
 use libublk::helpers::IoBuf;
 use libublk::io::{UblkDev, UblkQueue};
 use libublk::uring_async::ublk_run_ctrl_task;
+use libublk::UblkFlags;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
@@ -113,9 +113,9 @@ fn start_dev_fn(
 ///async control command, no need Rust async any more
 fn rd_add_dev(dev_id: i32, buf_addr: *mut u8, size: u64, for_add: bool) {
     let dev_flags = if for_add {
-        UBLK_DEV_F_ADD_DEV
+        UblkFlags::UBLK_DEV_F_ADD_DEV
     } else {
-        UBLK_DEV_F_RECOVER_DEV
+        UblkFlags::UBLK_DEV_F_RECOVER_DEV
     };
 
     let ctrl = Rc::new(

--- a/examples/ramdisk.rs
+++ b/examples/ramdisk.rs
@@ -2,7 +2,9 @@ use libublk::ctrl::UblkCtrl;
 ///! # Example of ramdisk
 ///
 /// Serves for covering recovery test[`test_ublk_ramdisk_recovery`],
-/// UblkCtrl::start_dev_in_queue() and low level interface example.
+///
+/// Build ramdisk target in single-thread conext, and the same technique
+/// will be extended to create multiple devices in single thread
 ///
 use libublk::helpers::IoBuf;
 use libublk::io::{UblkDev, UblkQueue};
@@ -79,6 +81,8 @@ fn queue_fn<'a>(
     (q_rc, exe, f_vec)
 }
 
+/// Start device in async IO task, in which both control and io rings
+/// are driven in current context
 fn start_dev_fn(
     ctrl_rc: &Rc<UblkCtrl>,
     dev_arc: &Arc<UblkDev>,
@@ -140,7 +144,7 @@ fn rd_add_dev(dev_id: i32, buf_addr: *mut u8, size: u64, for_add: bool) {
     // spawn async io tasks, and return io task array
     let (q_rc, exe, f_vec) = queue_fn(&dev, buf_addr);
 
-    // start device by running one async control task
+    // start device via async task
     let res = start_dev_fn(&ctrl, &dev, &ctrl_exe, &q_rc, &exe);
 
     if res >= 0 {

--- a/src/ctrl.rs
+++ b/src/ctrl.rs
@@ -1044,10 +1044,9 @@ impl UblkCtrl {
 
     /// Allocate one simple UblkCtrl device for delelting, listing, recovering,..,
     /// and it can't be done for adding device
-    pub fn new_simple(id: i32, dev_flags: u32) -> Result<UblkCtrl, UblkError> {
-        assert!((dev_flags & dev_flags::UBLK_DEV_F_ADD_DEV) == 0);
+    pub fn new_simple(id: i32) -> Result<UblkCtrl, UblkError> {
         assert!(id >= 0);
-        Self::new(None, id, 0, 0, 0, 0, 0, dev_flags)
+        Self::new(None, id, 0, 0, 0, 0, 0, 0)
     }
 
     /// Return current device info
@@ -1642,7 +1641,7 @@ mod tests {
 
         //count all existed ublk devices
         UblkCtrl::for_each_dev_id(move |dev_id| {
-            let ctrl = UblkCtrl::new_simple(dev_id as i32, 0).unwrap();
+            let ctrl = UblkCtrl::new_simple(dev_id as i32).unwrap();
             cnt.set(cnt.get() + 1);
 
             let dev_path = ctrl.get_cdev_path();

--- a/src/io.rs
+++ b/src/io.rs
@@ -527,7 +527,7 @@ impl UblkQueue<'_> {
             )
         };
         if io_cmd_buf == libc::MAP_FAILED {
-            return Err(UblkError::MmapError(unsafe { *libc::__errno_location() }));
+            return Err(UblkError::OtherIOError(std::io::Error::last_os_error()));
         }
 
         let nr_ios = depth + tgt.extra_ios as u32;
@@ -1012,7 +1012,7 @@ impl UblkQueue<'_> {
         #[allow(clippy::collapsible_if)]
         if state.queue_is_done() {
             if self.q_ring.borrow_mut().submission().is_empty() {
-                return Err(UblkError::QueueIsDown(-libc::ENODEV));
+                return Err(UblkError::QueueIsDown);
             }
         }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1022,7 +1022,7 @@ impl UblkQueue<'_> {
             Err(ref err) if err.raw_os_error() == Some(libc::ETIME) => {
                 return Err(UblkError::UringTimeout);
             }
-            Err(err) => return Err(UblkError::UringSubmissionError(err)),
+            Err(err) => return Err(UblkError::OtherIOError(err)),
             Ok(_) => {}
         };
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -525,7 +525,7 @@ impl UblkQueue<'_> {
             )
         };
         if io_cmd_buf == libc::MAP_FAILED {
-            return Err(UblkError::OtherIOError(std::io::Error::last_os_error()));
+            return Err(UblkError::IOError(std::io::Error::last_os_error()));
         }
 
         let nr_ios = depth + tgt.extra_ios as u32;
@@ -1020,7 +1020,7 @@ impl UblkQueue<'_> {
             Err(ref err) if err.raw_os_error() == Some(libc::ETIME) => {
                 return Err(UblkError::UringTimeout);
             }
-            Err(err) => return Err(UblkError::OtherIOError(err)),
+            Err(err) => return Err(UblkError::IOError(err)),
             Ok(_) => {}
         };
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -499,8 +499,7 @@ impl UblkQueue<'_> {
         let ring = IoUring::<squeue::Entry, cqueue::Entry>::builder()
             .setup_cqsize(cq_depth as u32)
             .setup_coop_taskrun()
-            .build(sq_depth as u32)
-            .map_err(UblkError::OtherIOError)?;
+            .build(sq_depth as u32)?;
 
         //todo: apply io_uring flags from tgt.ring_flags
 
@@ -509,8 +508,7 @@ impl UblkQueue<'_> {
         let cmd_buf_sz = UblkQueue::cmd_buf_sz(depth) as usize;
 
         ring.submitter()
-            .register_files(&tgt.fds[0..tgt.nr_fds as usize])
-            .map_err(UblkError::OtherIOError)?;
+            .register_files(&tgt.fds[0..tgt.nr_fds as usize])?;
 
         let off = sys::UBLKSRV_CMD_BUF_OFFSET as i64
             + q_id as i64

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,8 @@ pub enum UblkError {
     #[error("json failure")]
     JsonError(#[from] serde_json::Error),
 
-    #[error("mmap failure")]
-    MmapError(i32),
-
     #[error("queue down failure")]
-    QueueIsDown(i32),
+    QueueIsDown,
 
     #[error("other IO failure")]
     OtherIOError(#[source] std::io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,9 @@ pub enum UblkError {
     #[error("IO Queued")]
     IoQueued(i32),
 
+    #[error("Invalid input")]
+    InvalidVal,
+
     #[error("other failure")]
     OtherError(i32),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,10 +65,10 @@ pub enum UblkError {
     UringSubmissionError(#[source] std::io::Error),
 
     #[error("uring submission timeout")]
-    UringSubmissionTimeout(i32),
+    UringTimeout,
 
-    #[error("failed to push SQE to uring")]
-    UringPushError(#[from] io_uring::squeue::PushError),
+    #[error("IO Queued")]
+    UringIoQueued,
 
     #[error("io_uring IO failure")]
     UringIOError(i32),
@@ -84,9 +84,6 @@ pub enum UblkError {
 
     #[error("other IO failure")]
     OtherIOError(#[source] std::io::Error),
-
-    #[error("IO Queued")]
-    IoQueued(i32),
 
     #[error("Invalid input")]
     InvalidVal,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,6 @@ pub enum UblkIORes {
 
 #[derive(thiserror::Error, Debug)]
 pub enum UblkError {
-    #[error("failed to read the key file")]
-    UringSubmissionError(#[source] std::io::Error),
-
     #[error("uring submission timeout")]
     UringTimeout,
 
@@ -80,7 +77,7 @@ pub enum UblkError {
     QueueIsDown,
 
     #[error("other IO failure")]
-    OtherIOError(#[source] std::io::Error),
+    OtherIOError(#[from] std::io::Error),
 
     #[error("Invalid input")]
     InvalidVal,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub enum UblkError {
     QueueIsDown,
 
     #[error("other IO failure")]
-    OtherIOError(#[from] std::io::Error),
+    IOError(#[from] std::io::Error),
 
     #[error("Invalid input")]
     InvalidVal,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! and introduction doc in
 //! `<https://github.com/ming1/ubdsrv/blob/master/doc/ublk_intro.pdf>`
 
-use log::error;
+use bitflags::bitflags;
 
 pub mod ctrl;
 pub mod helpers;
@@ -13,22 +13,22 @@ pub mod io;
 pub mod sys;
 pub mod uring_async;
 
-/// Don't use the top 8 bits, which are reserved for internal uses
-pub mod dev_flags {
-    /// feature: support IO batch completion from single IO tag, typical
-    /// usecase is to complete IOs from eventfd CQE handler
-    pub const UBLK_DEV_F_COMP_BATCH: u32 = 1u32 << 0;
+bitflags! {
+    #[derive(Default, Debug, PartialEq, Eq, Copy, Clone)]
+    /// UblkFlags: top 8bits are reserved for internal use
+    pub struct UblkFlags: u32 {
+        /// feature: support IO batch completion from single IO tag, typical
+        /// usecase is to complete IOs from eventfd CQE handler
+        const UBLK_DEV_F_COMP_BATCH = 0b00000001;
 
-    /// tell UblkCtrl that we are adding one new device
-    pub const UBLK_DEV_F_ADD_DEV: u32 = 1u32 << 1;
+        /// tell UblkCtrl that we are adding one new device
+        const UBLK_DEV_F_ADD_DEV = 0b00000010;
 
-    /// tell UblkCtrl that we are recovering one old device
-    pub const UBLK_DEV_F_RECOVER_DEV: u32 = 1u32 << 2;
+        /// tell UblkCtrl that we are recovering one old device
+        const UBLK_DEV_F_RECOVER_DEV = 0b00000100;
 
-    pub(crate) const UBLK_DEV_F_INTERNAL_0: u32 = 1u32 << 31;
-
-    pub const UBLK_DEV_F_ALL: u32 =
-        UBLK_DEV_F_COMP_BATCH | UBLK_DEV_F_ADD_DEV | UBLK_DEV_F_RECOVER_DEV;
+        const UBLK_DEV_F_INTERNAL_0 = 1_u32 << 31;
+    }
 }
 
 /// Ublk Fat completion result

--- a/src/uring_async.rs
+++ b/src/uring_async.rs
@@ -109,10 +109,7 @@ fn ublk_process_queue_io(
     nr_waits: usize,
 ) -> Result<i32, UblkError> {
     let res = q.flush_and_wake_io_tasks(|data, cqe, _| ublk_wake_task(data, cqe), nr_waits);
-
-    if res.is_ok() {
-        while exe.try_tick() {}
-    }
+    while exe.try_tick() {}
 
     res
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -28,9 +28,7 @@ mod integration {
         let json_path = Path::new(&run_path);
         assert!(json_path.exists() == true);
 
-        let metadata = std::fs::metadata(json_path)
-            .map_err(UblkError::OtherIOError)
-            .unwrap();
+        let metadata = std::fs::metadata(json_path).unwrap();
         let permissions = metadata.permissions();
         assert!((permissions.mode() & 0o777) == 0o700);
     }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -447,7 +447,7 @@ mod integration {
         }
         assert!(tid != 0);
 
-        let ctrl = UblkCtrl::new_simple(id, 0).unwrap();
+        let ctrl = UblkCtrl::new_simple(id).unwrap();
         ublk_state_wait_until(&ctrl, sys::UBLK_S_DEV_LIVE as u16, 2000);
 
         //ublk block device should be observed now

--- a/utils/ublk_user_id_rs.rs
+++ b/utils/ublk_user_id_rs.rs
@@ -5,7 +5,7 @@ fn main() {
 
     if s.len() >= 6 && (&s[0..5] == "ublkb" || &s[0..5] == "ublkc") {
         match s[5..].parse::<i32>() {
-            Ok(id) => match libublk::ctrl::UblkCtrl::new_simple(id, 0) {
+            Ok(id) => match libublk::ctrl::UblkCtrl::new_simple(id) {
                 Ok(ctrl) => {
                     let dinfo = ctrl.dev_info();
                     if (dinfo.flags & libublk::sys::UBLK_F_UNPRIVILEGED_DEV as u64) != 0 {


### PR DESCRIPTION
- cleanup UblkError
- Convert dev_flags into Rust UblkFlags(bitflags)
- simplify retry for ioctl encode command
- re-organize examples/null.rs & examples/loop.rs