### PR TITLE
Pre dev 0.3: cleanup io & uring_async

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ fn main() {
         // target initialization
         |dev| {
             dev.set_default_params(250_u64 << 30);
-            Ok(0)
+            Ok(())
         },
         // queue IO logic
         |tag, dev| q_fn(tag, dev),

--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -195,14 +195,8 @@ fn lo_handle_io_cmd_sync(q: &UblkQueue<'_>, tag: u16, i: &UblkIOCtx, buf_addr: *
         // either start to handle or retry
         let off = (iod.start_sector << 9) as u64;
         let bytes = (iod.nr_sectors << 9) as u32;
-        let sqe = __lo_make_io_sqe(op, off, bytes, buf_addr).user_data(data);
-        unsafe {
-            q.q_ring
-                .borrow_mut()
-                .submission()
-                .push(&sqe)
-                .expect("submission fail");
-        }
+        let sqe = __lo_make_io_sqe(op, off, bytes, buf_addr);
+        q.ublk_submit_sqe_sync(sqe, data).unwrap();
     }
 }
 

--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -81,7 +81,7 @@ fn lo_file_size(f: &std::fs::File) -> Result<(u64, u8, u8)> {
 }
 
 // setup loop target
-fn lo_init_tgt(dev: &mut UblkDev, lo: &LoopTgt) -> Result<i32, UblkError> {
+fn lo_init_tgt(dev: &mut UblkDev, lo: &LoopTgt) -> Result<(), UblkError> {
     trace!("loop: init_tgt {}", dev.dev_info.dev_id);
     if lo.direct_io != 0 {
         unsafe {
@@ -113,7 +113,7 @@ fn lo_init_tgt(dev: &mut UblkDev, lo: &LoopTgt) -> Result<i32, UblkError> {
     let val = serde_json::json!({"loop": LoJson { back_file_path: lo.back_file_path.clone(), direct_io: 1 } });
     dev.set_target_json(val);
 
-    Ok(0)
+    Ok(())
 }
 
 #[inline]

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -60,16 +60,18 @@ fn q_async_fn(qid: u16, dev: &UblkDev, user_copy: bool) {
         let q = q_rc.clone();
 
         f_vec.push(exe.spawn(async move {
-            let buf = IoBuf::<u8>::new(q.dev.dev_info.max_io_buf_bytes as usize);
             let mut cmd_op = libublk::sys::UBLK_U_IO_FETCH_REQ;
             let mut res = 0;
-            let buf_addr = if user_copy {
-                std::ptr::null_mut()
+            let (_buf, buf_addr) = if user_copy {
+                (None, std::ptr::null_mut())
             } else {
-                buf.as_mut_ptr()
+                let buf = IoBuf::<u8>::new(q.dev.dev_info.max_io_buf_bytes as usize);
+
+                q.register_io_buf(tag, &buf);
+                let addr = buf.as_mut_ptr();
+                (Some(buf), addr)
             };
 
-            q.register_io_buf(tag, &buf);
             loop {
                 let cmd_res = q.submit_io_cmd(tag, cmd_op, buf_addr, res).await;
                 if cmd_res == libublk::sys::UBLK_IO_RES_ABORT {

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -109,7 +109,7 @@ fn __null_add(
         .unwrap();
     let tgt_init = |dev: &mut UblkDev| {
         dev.set_default_params(250_u64 << 30);
-        Ok(0)
+        Ok(())
     };
     let user_copy = (ctrl.dev_info().flags & libublk::sys::UBLK_F_USER_COPY as u64) != 0;
     let wh = move |d_ctrl: &UblkCtrl| {

--- a/examples/ramdisk.rs
+++ b/examples/ramdisk.rs
@@ -106,7 +106,7 @@ fn rd_add_dev(dev_id: i32, buf_addr: *mut u8, size: u64, for_add: bool) {
 
     let tgt_init = |dev: &mut UblkDev| {
         dev.set_default_params(size);
-        Ok(0)
+        Ok(())
     };
     let dev_arc = Arc::new(UblkDev::new(ctrl.get_name(), tgt_init, &ctrl).unwrap());
     let dev_clone = dev_arc.clone();

--- a/src/ctrl.rs
+++ b/src/ctrl.rs
@@ -73,15 +73,14 @@ const CTRL_CMD_BUF_READ: u32 = 8;
 /// case of unprivileged ublk, such as get_features(), add_dev().
 const CTRL_CMD_NO_NEED_DEV_PATH: u32 = 16;
 
-#[allow(dead_code)]
 #[derive(Debug, Default, Copy, Clone)]
 struct UblkCtrlCmdData {
     cmd_op: u32,
     flags: u32,
     data: u64,
     dev_path_len: u16,
-    pad: u16,
-    reserved: u32,
+    _pad: u16,
+    _reserved: u32,
 
     addr: u64,
     len: u32,

--- a/src/ctrl.rs
+++ b/src/ctrl.rs
@@ -1424,7 +1424,7 @@ impl UblkCtrl {
     /// io handler, such as setup async/await for handling io command.
     pub fn run_target<T, Q, W>(&self, tgt_fn: T, q_fn: Q, device_fn: W) -> Result<i32, UblkError>
     where
-        T: FnOnce(&mut UblkDev) -> Result<i32, UblkError>,
+        T: FnOnce(&mut UblkDev) -> Result<(), UblkError>,
         Q: FnOnce(u16, &UblkDev) + Send + Sync + Clone + 'static,
         W: FnOnce(&UblkCtrl) + Send + Sync + 'static,
     {
@@ -1538,7 +1538,7 @@ mod tests {
         let tgt_init = |dev: &mut UblkDev| {
             dev.set_default_params(250_u64 << 30);
             dev.set_target_json(serde_json::json!({"null": "test_data" }));
-            Ok(0)
+            Ok(())
         };
         let dev = UblkDev::new(ctrl.get_name(), tgt_init, &ctrl).unwrap();
 
@@ -1564,7 +1564,7 @@ mod tests {
         let tgt_init = |dev: &mut UblkDev| {
             dev.set_default_params(250_u64 << 30);
             dev.set_target_json(serde_json::json!({"null": "test_data" }));
-            Ok(0)
+            Ok(())
         };
         let q_fn = move |qid: u16, dev: &UblkDev| {
             let bufs_rc = Rc::new(dev.alloc_queue_io_bufs());

--- a/src/io.rs
+++ b/src/io.rs
@@ -596,8 +596,7 @@ impl UblkQueue<'_> {
         unsafe { &*iod }
     }
 
-    #[inline(always)]
-    pub fn get_io_buf_addr(&self, tag: u16) -> *mut u8 {
+    fn get_io_buf_addr(&self, tag: u16) -> *mut u8 {
         self.bufs.borrow()[tag as usize]
     }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -418,7 +418,6 @@ impl UblkQueueState {
 ///
 /// So far, each queue is handled by one its own io_uring.
 ///
-#[allow(dead_code)]
 pub struct UblkQueue<'a> {
     flags: UblkFlags,
     q_id: u16,
@@ -637,7 +636,6 @@ impl UblkQueue<'_> {
     }
 
     #[inline(always)]
-    #[allow(unused_assignments)]
     fn __queue_io_cmd(
         &self,
         r: &mut IoUring<squeue::Entry>,
@@ -865,7 +863,6 @@ impl UblkQueue<'_> {
     }
 
     #[inline(always)]
-    #[allow(unused_assignments)]
     fn handle_cqe<F>(&self, mut ops: F, e: &UblkIOCtx)
     where
         F: FnMut(&UblkQueue, u16, &UblkIOCtx),

--- a/src/io.rs
+++ b/src/io.rs
@@ -232,7 +232,7 @@ impl UblkDev {
     /// structure which implements UblkTgtImpl.
     pub fn new<F>(tgt_name: String, ops: F, ctrl: &UblkCtrl) -> Result<UblkDev, UblkError>
     where
-        F: FnOnce(&mut UblkDev) -> Result<i32, UblkError>,
+        F: FnOnce(&mut UblkDev) -> Result<(), UblkError>,
     {
         let info = ctrl.dev_info();
         let mut tgt = UblkTgt {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -55,7 +55,7 @@ mod integration {
             .unwrap();
         let tgt_init = |dev: &mut UblkDev| {
             dev.set_default_params(250_u64 << 30);
-            Ok(0)
+            Ok(())
         };
 
         let q_fn = move |qid: u16, _dev: &UblkDev| {
@@ -172,7 +172,7 @@ mod integration {
 
         let tgt_init = |dev: &mut UblkDev| {
             dev.set_default_params(250_u64 << 30);
-            Ok(0)
+            Ok(())
         };
         // device data is shared among all queue contexts
         let dev_data = Arc::new(Mutex::new(DevData { done: 0 }));
@@ -310,7 +310,7 @@ mod integration {
             .unwrap();
         let tgt_init = |dev: &mut UblkDev| {
             dev.set_default_params(size);
-            Ok(0)
+            Ok(())
         };
 
         let q_fn = move |qid: u16, dev: &UblkDev| {


### PR DESCRIPTION
- improve comment on uring_async
- change return value of tgt_init into Result<(), UblkError>
- don't expose UblkQeue::q_ring, by adding UblkQueue::ublk_submit_sqe_sync(), and UblkQueue::uring_op() &
UblkQueue::uring_op_mut()
- don't expose UblkQueue::get_io_buf_addr
- example/null: avoid to allocate io buffer for user_copy