### PR TITLE
Delete unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,9 @@ scripts = ["utils/ublk_chown.sh"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-pkg-config = "0.3"
 bindgen = "0.69"
 regex = "1.8.3"
-anyhow = {version = "1.0.66", features = ["default"]}
+anyhow = "1.0.66"
 
 [dependencies]
 libc = "0.2"
@@ -41,8 +40,6 @@ serde_json = "1.0.79"
 bitmaps = "3.2.0"
 log = {version = "0.4", features = ["release_max_level_off"]}
 thiserror = "1.0.43"
-futures = "0.3.31"
-env_logger = "0.9"
 smol = "2.0.2"
 slab = "0.4.9"
 derive_setters = "0.1"
@@ -52,10 +49,10 @@ bitflags = "2.4.1"
 block-utils = "0.11.0"
 tempfile = "3.6.0"
 regex = "1.8.4"
-anyhow = {version = "1.0.66", features = ["default"]}
+anyhow = "1.0.66"
 clap = "4.3"
 nix = "0.26.2"
 ilog = "1.0.1"
-async-std = {version = "1.12.0"}
-ctrlc = "3.4.0"
 daemonize = "0.5"
+env_logger = "0.9"
+futures = "0.3.31"


### PR DESCRIPTION
- `pkg-config` is not used by libublk's build script
- `futures` is not used by the library, only tests and example code
- `env_logger` is not used by the library, only example code
- `async-std` and `ctrlc` are not used at all
- specifying `features = ["default"]` on any dependency is redundant because default features are enabled by default