### PR TITLE
Misc refactor optimization

### DIFF
--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -238,7 +238,8 @@ fn q_fn(qid: u16, dev: &UblkDev) {
 
     let queue = match UblkQueue::new(qid, dev)
         .unwrap()
-        .submit_fetch_commands_unified(BufDescList::Slices(Some(&bufs))) {
+        .submit_fetch_commands_unified(BufDescList::Slices(Some(&bufs)))
+    {
         Ok(q) => q,
         Err(e) => {
             log::error!("submit_fetch_commands_unified failed: {}", e);
@@ -255,7 +256,8 @@ async fn lo_io_task(q: &UblkQueue<'_>, tag: u16) -> Result<(), UblkError> {
 
     // Submit initial prep command - any error will exit the function
     // The IoBuf is automatically registered
-    q.submit_io_prep_cmd(tag, BufDesc::Slice(buf.as_slice()), 0, Some(&buf)).await?;
+    q.submit_io_prep_cmd(tag, BufDesc::Slice(buf.as_slice()), 0, Some(&buf))
+        .await?;
 
     loop {
         // Use safe slice access for I/O operations
@@ -265,7 +267,8 @@ async fn lo_io_task(q: &UblkQueue<'_>, tag: u16) -> Result<(), UblkError> {
         let res = lo_handle_io_cmd_async(&q, tag, io_slice).await;
 
         // Any error (including QueueIsDown) will break the loop by exiting the function
-        q.submit_io_commit_cmd(tag, BufDesc::Slice(buf.as_slice()), res).await?;
+        q.submit_io_commit_cmd(tag, BufDesc::Slice(buf.as_slice()), res)
+            .await?;
     }
 }
 
@@ -280,8 +283,7 @@ fn q_a_fn(qid: u16, dev: &UblkDev, depth: u16) {
         f_vec.push(exe.spawn(async move {
             match lo_io_task(&q, tag).await {
                 Err(UblkError::QueueIsDown) | Ok(_) => {}
-                Err(e) =>
-                    log::error!("lo_io_task failed for tag {}: {}", tag, e),
+                Err(e) => log::error!("lo_io_task failed for tag {}: {}", tag, e),
             }
         }));
     }

--- a/examples/ramdisk.rs
+++ b/examples/ramdisk.rs
@@ -82,7 +82,8 @@ async fn io_task(q: &UblkQueue<'_>, tag: u16, ramdisk_storage: &mut [u8]) -> Res
 
     // Submit initial prep command - any error will exit the function
     // The IoBuf is automatically registered
-    q.submit_io_prep_cmd(tag, BufDesc::Slice(buffer.as_slice()), 0, Some(&buffer)).await?;
+    q.submit_io_prep_cmd(tag, BufDesc::Slice(buffer.as_slice()), 0, Some(&buffer))
+        .await?;
 
     loop {
         // Use safe slice access for memory operations
@@ -92,7 +93,8 @@ async fn io_task(q: &UblkQueue<'_>, tag: u16, ramdisk_storage: &mut [u8]) -> Res
         let res = handle_io(&q, tag, io_slice, ramdisk_storage);
 
         // Any error (including QueueIsDown) will break the loop by exiting the function
-        q.submit_io_commit_cmd(tag, BufDesc::Slice(buffer.as_slice()), res).await?;
+        q.submit_io_commit_cmd(tag, BufDesc::Slice(buffer.as_slice()), res)
+            .await?;
     }
 }
 
@@ -189,8 +191,7 @@ fn rd_add_dev(dev_id: i32, ramdisk_storage: &mut [u8], size: u64, for_add: bool,
             let storage_slice = unsafe { std::slice::from_raw_parts_mut(storage_ptr, storage_len) };
             match io_task(&q_clone, tag, storage_slice).await {
                 Err(UblkError::QueueIsDown) | Ok(_) => {}
-                Err(e) =>
-                    log::error!("io_task failed for tag {}: {}", tag, e)
+                Err(e) => log::error!("io_task failed for tag {}: {}", tag, e),
             }
         }));
     }

--- a/src/ctrl.rs
+++ b/src/ctrl.rs
@@ -768,11 +768,11 @@ pub(crate) struct UblkCtrlInner {
 
 /// Affinity management helpers
 impl UblkCtrlInner {
-   /// enable async/await API enforcement: when set, only async/await control
-   /// APIs can be used; when not set, only synchronous control APIs can be used
-   pub(crate) const UBLK_CTRL_ASYNC_AWAIT:UblkFlags = UblkFlags::UBLK_DEV_F_INTERNAL_3;
+    /// enable async/await API enforcement: when set, only async/await control
+    /// APIs can be used; when not set, only synchronous control APIs can be used
+    pub(crate) const UBLK_CTRL_ASYNC_AWAIT: UblkFlags = UblkFlags::UBLK_DEV_F_INTERNAL_3;
 
-   async fn get_queue_affinity_effective_async(
+    async fn get_queue_affinity_effective_async(
         &mut self,
         qid: u16,
     ) -> Result<UblkQueueAffinity, UblkError> {
@@ -1343,7 +1343,11 @@ impl UblkCtrlInner {
 
     async fn ublk_ctrl_cmd_async(&mut self, data: &UblkCtrlCmdData) -> Result<i32, UblkError> {
         // Enforce async/await API usage: async methods can only be used when UBLK_CTRL_ASYNC_AWAIT is set
-        if !self.force_async && !self.dev_flags.contains(UblkCtrlInner::UBLK_CTRL_ASYNC_AWAIT) {
+        if !self.force_async
+            && !self
+                .dev_flags
+                .contains(UblkCtrlInner::UBLK_CTRL_ASYNC_AWAIT)
+        {
             log::warn!("Warn: async cmd {:x} is run from sync context", data.cmd_op);
             return Err(UblkError::OtherError(-libc::EPERM));
         }
@@ -1367,7 +1371,11 @@ impl UblkCtrlInner {
 
     fn ublk_ctrl_cmd(&mut self, data: &UblkCtrlCmdData) -> Result<i32, UblkError> {
         // Enforce non-async API usage: sync methods can only be used when UBLK_CTRL_ASYNC_AWAIT is NOT set
-        if !self.force_sync && self.dev_flags.contains(UblkCtrlInner::UBLK_CTRL_ASYNC_AWAIT) {
+        if !self.force_sync
+            && self
+                .dev_flags
+                .contains(UblkCtrlInner::UBLK_CTRL_ASYNC_AWAIT)
+        {
             log::warn!("Warn: sync cmd {:x} is run from async context", data.cmd_op);
             return Err(UblkError::OtherError(-libc::EPERM));
         }
@@ -1597,7 +1605,10 @@ impl UblkCtrlInner {
 
     /// Retrieve this device's parameter from ublk driver by
     /// sending command in async/.await
-    pub(crate) async fn get_params_async(&mut self, params: &mut sys::ublk_params) -> Result<i32, UblkError> {
+    pub(crate) async fn get_params_async(
+        &mut self,
+        params: &mut sys::ublk_params,
+    ) -> Result<i32, UblkError> {
         let data = Self::prepare_get_params_cmd(params);
         self.ublk_ctrl_cmd_async(&data).await
     }
@@ -1624,7 +1635,10 @@ impl UblkCtrlInner {
     ///
     /// Note: device parameter has to send to driver before starting
     /// this device
-    pub(crate) async fn set_params_async(&mut self, params: &sys::ublk_params) -> Result<i32, UblkError> {
+    pub(crate) async fn set_params_async(
+        &mut self,
+        params: &sys::ublk_params,
+    ) -> Result<i32, UblkError> {
         let mut p = *params;
 
         p.len = core::mem::size_of::<sys::ublk_params>() as u32;
@@ -2045,7 +2059,6 @@ impl UblkCtrl {
         tgt_flags: u64,
         dev_flags: UblkFlags,
     ) -> Result<UblkCtrl, UblkError> {
-
         if dev_flags.intersects(UblkCtrlInner::UBLK_CTRL_ASYNC_AWAIT) {
             return Err(UblkError::InvalidVal);
         }
@@ -2073,8 +2086,6 @@ impl UblkCtrl {
         Self::new(None, id, 0, 0, 0, 0, 0, UblkFlags::empty())
     }
 
-
-
     /// Return current device info
     pub fn dev_info(&self) -> sys::ublksrv_ctrl_dev_info {
         self.get_inner().dev_info
@@ -2095,7 +2106,11 @@ impl UblkCtrl {
 
     /// Return ublk block device path
     pub fn get_bdev_path(&self) -> String {
-        format!("{}{}", UblkCtrlInner::BDEV_PATH, self.get_inner().dev_info.dev_id)
+        format!(
+            "{}{}",
+            UblkCtrlInner::BDEV_PATH,
+            self.get_inner().dev_info.dev_id
+        )
     }
 
     /// Get queue's pthread id from exported json file for this device
@@ -2162,7 +2177,6 @@ impl UblkCtrl {
         Ok(0)
     }
 
-
     pub fn dump(&self) {
         let mut ctrl = self.get_inner_mut();
         let mut p = sys::ublk_params {
@@ -2183,7 +2197,6 @@ impl UblkCtrl {
         ctrl.dump_from_json();
         println!("\tublksrv_flags: 0x{:x}", ctrl.dev_info.ublksrv_flags);
     }
-
 
     pub fn run_dir() -> String {
         String::from("/run/ublksrvd")
@@ -2211,7 +2224,6 @@ impl UblkCtrl {
         self.get_inner_mut().read_dev_info()
     }
 
-
     /// Retrieve this device's parameter from ublk driver by
     /// sending command
     ///
@@ -2219,7 +2231,6 @@ impl UblkCtrl {
     pub fn get_params(&self, params: &mut sys::ublk_params) -> Result<i32, UblkError> {
         self.get_inner_mut().get_params(params)
     }
-
 
     /// Send this device's parameter to ublk driver
     ///
@@ -2229,13 +2240,11 @@ impl UblkCtrl {
         self.get_inner_mut().set_params(params)
     }
 
-
     /// Retrieving the specified queue's affinity from ublk driver
     ///
     pub fn get_queue_affinity(&self, q: u32, bm: &mut UblkQueueAffinity) -> Result<i32, UblkError> {
         self.get_inner_mut().get_queue_affinity(q, bm)
     }
-
 
     /// Set single CPU affinity for a specific queue
     ///
@@ -2320,7 +2329,6 @@ impl UblkCtrl {
         }
     }
 
-
     /// Start ublk device
     ///
     /// # Arguments:
@@ -2390,7 +2398,6 @@ impl UblkCtrl {
         ctrl.stop()
     }
 
-
     /// Kill this device
     ///
     /// Preferred method for target code to stop & delete device,
@@ -2402,7 +2409,6 @@ impl UblkCtrl {
     pub fn kill_dev(&self) -> Result<i32, UblkError> {
         self.get_inner_mut().stop()
     }
-
 
     /// Remove this device and its exported json file
     ///
@@ -2434,7 +2440,6 @@ impl UblkCtrl {
         Ok(0)
     }
 
-
     /// Calculate queue affinity based on device settings
     ///
     /// This function calculates the appropriate CPU affinity for a queue,
@@ -2450,7 +2455,6 @@ impl UblkCtrl {
                 affinity
             })
     }
-
 
     /// Set queue thread affinity using thread ID
     ///
@@ -2469,7 +2473,6 @@ impl UblkCtrl {
             );
         }
     }
-
 
     /// Initialize queue thread and return tid
     ///
@@ -2715,7 +2718,6 @@ mod tests {
         assert_eq!(inner.queue_selected_cpus[1], 0); // Should be initialized to 0
     }
 
-
     #[test]
     fn test_get_queue_effective_affinity() {
         let ctrl = UblkCtrlBuilder::default()
@@ -2801,7 +2803,8 @@ mod tests {
 
             let queue = match UblkQueue::new(qid, dev)
                 .unwrap()
-                .submit_fetch_commands_unified(BufDescList::Slices(Some(&bufs))) {
+                .submit_fetch_commands_unified(BufDescList::Slices(Some(&bufs)))
+            {
                 Ok(q) => q,
                 Err(e) => {
                     log::error!("submit_fetch_commands_unified failed: {}", e);
@@ -2951,11 +2954,4 @@ mod tests {
         println!("  - Single CPU affinity creation: PASS");
         println!("  - Random CPU selection: PASS (selected CPU {})", cpu);
     }
-
-
-
-
-
-
-
 }

--- a/src/ctrl_async.rs
+++ b/src/ctrl_async.rs
@@ -3,9 +3,9 @@
 use super::ctrl::{UblkCtrlInner, UblkQueueAffinity};
 use super::io::UblkDev;
 use super::{sys, UblkError, UblkFlags};
+use std::fs;
 use std::path::Path;
 use std::sync::RwLock;
-use std::fs;
 
 /// Async version of ublk control device
 ///
@@ -73,7 +73,6 @@ impl UblkCtrlAsync {
         tgt_flags: u64,
         dev_flags: UblkFlags,
     ) -> Result<UblkCtrlAsync, UblkError> {
-
         UblkCtrlInner::validate_new_params(flags, dev_flags, id, nr_queues, depth, io_buf_bytes)?;
 
         let inner = RwLock::new(
@@ -128,7 +127,11 @@ impl UblkCtrlAsync {
 
     /// Return ublk block device path
     pub fn get_bdev_path(&self) -> String {
-        format!("{}{}", UblkCtrlInner::BDEV_PATH, self.get_inner().dev_info.dev_id)
+        format!(
+            "{}{}",
+            UblkCtrlInner::BDEV_PATH,
+            self.get_inner().dev_info.dev_id
+        )
     }
 
     /// Get queue's pthread id from exported json file for this device
@@ -592,7 +595,8 @@ mod tests {
             }
 
             // Test new_simple_async
-            let result_simple = UblkCtrlAsync::new_simple_async(ctrl.dev_info().dev_id as i32).await;
+            let result_simple =
+                UblkCtrlAsync::new_simple_async(ctrl.dev_info().dev_id as i32).await;
             match result_simple {
                 Ok(_ctrl) => println!("✓ new_simple_async: Successfully created simple device"),
                 Err(_e) => {
@@ -619,7 +623,8 @@ mod tests {
 
         // Submit initial prep command and handle any errors (including queue down)
         // The IoBuf is automatically registered
-        q.submit_io_prep_cmd(tag, buf_desc.clone(), 0, _buf.as_ref()).await?;
+        q.submit_io_prep_cmd(tag, buf_desc.clone(), 0, _buf.as_ref())
+            .await?;
 
         loop {
             let res = (iod.nr_sectors << 9) as i32;

--- a/src/ctrl_async.rs
+++ b/src/ctrl_async.rs
@@ -423,41 +423,10 @@ impl UblkCtrlAsync {
 mod tests {
     use super::*;
     use crate::ctrl::{UblkCtrlBuilder, UblkQueueAffinity};
-    use crate::io::{UblkDev, UblkQueue};
-    use crate::uring_async::ublk_wake_task;
+    use crate::test_helpers::{device_handler_async, ublk_join_tasks};
     use crate::UblkError;
     use crate::{ctrl::UblkCtrl, UblkFlags};
     use std::rc::Rc;
-
-    /// Block on all tasks in the executor until they are finished
-    fn ublk_join_tasks<T>(
-        exe: &smol::LocalExecutor,
-        tasks: Vec<smol::Task<T>>,
-    ) -> Result<(), UblkError> {
-        use io_uring::{squeue, IoUring};
-        loop {
-            // Check if all tasks are finished
-            if tasks.iter().all(|task| task.is_finished()) {
-                break;
-            }
-
-            // Drive the executor to make progress on tasks
-            while exe.try_tick() {}
-
-            // Handle control uring events
-            let entry =
-                crate::ctrl::with_ctrl_ring_mut_internal!(|r: &mut IoUring<squeue::Entry128>| {
-                    match r.submit_and_wait(0) {
-                        Err(_) => None,
-                        _ => r.completion().next(),
-                    }
-                });
-            if let Some(cqe) = entry {
-                ublk_wake_task(cqe.user_data(), &cqe);
-            }
-        }
-        Ok(())
-    }
 
     #[test]
     fn test_get_queue_affinity_async() {
@@ -511,10 +480,6 @@ mod tests {
     /// Test async APIs
     #[test]
     fn test_async_apis() {
-        let _ = env_logger::builder()
-            .format_target(false)
-            .format_timestamp(None)
-            .try_init();
         let exe_rc = Rc::new(smol::LocalExecutor::new());
         let exe = exe_rc.clone();
 
@@ -612,110 +577,9 @@ mod tests {
         println!("✓ Async constructor methods are properly defined");
     }
 
-    async fn io_async_fn(tag: u16, q: &UblkQueue<'_>) -> Result<(), UblkError> {
-        use crate::helpers::IoBuf;
-        use crate::BufDesc;
-
-        let buf = IoBuf::<u8>::new(q.dev.dev_info.max_io_buf_bytes as usize);
-        let _buf = Some(buf);
-        let iod = q.get_iod(tag);
-        let buf_desc = BufDesc::Slice(_buf.as_ref().unwrap().as_slice());
-
-        // Submit initial prep command and handle any errors (including queue down)
-        // The IoBuf is automatically registered
-        q.submit_io_prep_cmd(tag, buf_desc.clone(), 0, _buf.as_ref())
-            .await?;
-
-        loop {
-            let res = (iod.nr_sectors << 9) as i32;
-            // Any error (including QueueIsDown) will break the loop
-            q.submit_io_commit_cmd(tag, buf_desc.clone(), res).await?;
-        }
-    }
-
-    fn q_async_fn<'a>(
-        exe: &smol::LocalExecutor<'a>,
-        q_rc: &Rc<UblkQueue<'a>>,
-        depth: u16,
-        f_vec: &mut Vec<smol::Task<()>>,
-    ) {
-        for tag in 0..depth as u16 {
-            let q = q_rc.clone();
-            f_vec.push(exe.spawn(async move {
-                if let Err(e) = io_async_fn(tag, &q).await {
-                    match e {
-                        UblkError::QueueIsDown => {
-                            // Queue down is expected during shutdown, don't log as error
-                        }
-                        _ => {
-                            log::debug!("io_async_fn failed for tag {}: {}", tag, e);
-                        }
-                    }
-                }
-            }));
-        }
-    }
-
-    async fn device_handler_async(dev_flags: UblkFlags) -> Result<(), UblkError> {
-        let ctrl = UblkCtrlBuilder::default()
-            .name("test_async")
-            .dev_flags(dev_flags)
-            .depth(8)
-            .build_async()
-            .await
-            .unwrap();
-
-        let tgt_init = |dev: &mut UblkDev| {
-            dev.set_default_params(250_u64 << 30);
-            Ok(())
-        };
-        // Use the new async method directly
-        let dev_arc = &std::sync::Arc::new(UblkDev::new_async(ctrl.get_name(), tgt_init, &ctrl)?);
-        let dev = dev_arc.clone();
-        assert!(dev_arc.dev_info.nr_hw_queues == 1);
-
-        // Todo: support to handle multiple queues in one thread context
-        let qh = std::thread::spawn(move || {
-            let q_rc = Rc::new(UblkQueue::new(0 as u16, &dev).unwrap());
-            let q = q_rc.clone();
-            let exe = smol::LocalExecutor::new();
-            let mut f_vec: Vec<smol::Task<()>> = Vec::new();
-
-            if dev_flags.contains(UblkFlags::UBLK_DEV_F_MLOCK_IO_BUFFER) {
-                q.mark_mlock_failed();
-            }
-
-            q_async_fn(&exe, &q, dev.dev_info.queue_depth as u16, &mut f_vec);
-
-            crate::uring_async::ublk_wait_and_handle_ios(&exe, &q_rc);
-            smol::block_on(exe.run(async { futures::future::join_all(f_vec).await }));
-        });
-
-        // Avoid to leak device
-        if let Err(_) = ctrl.start_dev_async(dev_arc).await {
-            log::warn!("device_handler_async: fail to start device(async)");
-        }
-
-        ctrl.dump_async().await?;
-        ctrl.kill_dev_async().await?;
-
-        // async/await needs to delete device by itself, otherwise we
-        // may hang in Drop() of UblkCtrlInner.
-        ctrl.del_dev_async_await().await?;
-
-        qh.join().unwrap_or_else(|_| {
-            eprintln!("dev-{} join queue thread failed", dev_arc.dev_info.dev_id)
-        });
-        Ok(())
-    }
-
     /// Test async APIs for building ublk device
     #[test]
     fn test_create_ublk_async() {
-        let _ = env_logger::builder()
-            .format_target(false)
-            .format_timestamp(None)
-            .try_init();
         let exe_rc = Rc::new(smol::LocalExecutor::new());
         let exe = exe_rc.clone();
         let mut fvec = Vec::new();
@@ -733,28 +597,6 @@ mod tests {
 
         smol::block_on(exe_rc.run(async move {
             let _ = ublk_join_tasks(&exe, fvec);
-        }));
-    }
-
-    #[test]
-    fn test_test_mlock_failure() {
-        let _ = env_logger::builder()
-            .format_target(false)
-            .format_timestamp(None)
-            .try_init();
-        let exe_rc = Rc::new(smol::LocalExecutor::new());
-        let exe = exe_rc.clone();
-
-        let io_task = exe_rc.spawn(async {
-            device_handler_async(
-                UblkFlags::UBLK_DEV_F_ADD_DEV | UblkFlags::UBLK_DEV_F_MLOCK_IO_BUFFER,
-            )
-            .await
-            .unwrap();
-        });
-
-        smol::block_on(exe_rc.run(async move {
-            let _ = ublk_join_tasks(&exe, vec![io_task]);
         }));
     }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1380,8 +1380,8 @@ impl UblkQueue<'_> {
     /// These methods handle buffer registration automatically and provide better
     /// integration with the async I/O workflow.
     #[deprecated(
-        since = "0.8.0",
-        note = "Use `submit_io_prep_cmd` and `submit_fetch_commands_unified` instead for automatic buffer registration"
+        since = "0.5.0",
+        note = "Use `submit_io_prep_cmd` and `submit_fetch_commands_unified` instead, removed in 0.6"
     )]
     pub fn register_io_buf(&self, tag: u16, buf: &IoBuf<u8>) {
         self.register_io_buf_internal(tag, buf);
@@ -1578,8 +1578,8 @@ impl UblkQueue<'_> {
     /// In case of zoned, `buf_addr` can be the returned LBA for zone append
     /// command.
     #[deprecated(
-        since = "0.8.0",
-        note = "Use `submit_io_prep_cmd` and `submit_io_commit_cmd` instead"
+        since = "0.5.0",
+        note = "Use `submit_io_prep_cmd` and `submit_io_commit_cmd` instead, removed in 0.6"
     )]
     #[inline]
     pub fn submit_io_cmd(
@@ -1606,8 +1606,8 @@ impl UblkQueue<'_> {
     /// When auto buffer registration is enabled, buf_addr should be set to the encoded
     /// auto buffer registration data instead of the actual buffer address.
     #[deprecated(
-        since = "0.8.0",
-        note = "Use `submit_io_prep_cmd` and `submit_io_commit_cmd` instead"
+        since = "0.5.0",
+        note = "Use `submit_io_prep_cmd` and `submit_io_commit_cmd` instead, removed in 0.6"
     )]
     #[inline]
     pub fn submit_io_cmd_with_auto_buf_reg(
@@ -1942,7 +1942,10 @@ impl UblkQueue<'_> {
     /// Only called during queue initialization. After queue is setup,
     /// COMMIT_AND_FETCH_REQ command is used for both committing io command
     /// result and fetching new incoming IO
-    #[deprecated(since = "0.8.0", note = "Use `submit_fetch_commands_unified` instead")]
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use `submit_fetch_commands_unified` instead, removed in 0.6"
+    )]
     pub fn submit_fetch_commands(self, bufs: Option<&Vec<IoBuf<u8>>>) -> Self {
         for i in 0..self.q_depth {
             let buf_addr = match bufs {
@@ -1980,7 +1983,10 @@ impl UblkQueue<'_> {
     /// Only called during queue initialization. After queue is setup,
     /// COMMIT_AND_FETCH_REQ command is used for both committing io command
     /// result and fetching new incoming IO.
-    #[deprecated(since = "0.8.0", note = "Use `submit_fetch_commands_unified` instead")]
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use `submit_fetch_commands_unified` instead, removed in 0.6"
+    )]
     pub fn submit_fetch_commands_with_auto_buf_reg(
         self,
         buf_reg_data_list: &[sys::ublk_auto_buf_reg],
@@ -2105,7 +2111,10 @@ impl UblkQueue<'_> {
     ///
     /// When calling this API, target code has to make sure that thread-local QUEUE_RING
     /// won't be borrowed.
-    #[deprecated(since = "0.8.0", note = "Use `complete_io_cmd_unified` instead")]
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use `complete_io_cmd_unified` instead, removed in 0.6"
+    )]
     #[inline]
     pub fn complete_io_cmd(&self, tag: u16, buf_addr: *mut u8, res: Result<UblkIORes, UblkError>) {
         with_queue_ring_mut_internal!(|r: &mut IoUring<squeue::Entry>| {
@@ -2168,7 +2177,10 @@ impl UblkQueue<'_> {
     /// This method supports zero-copy operations when UBLK_F_AUTO_BUF_REG is enabled.
     /// The buffer is automatically registered using the provided registration data.
     /// When calling this API, target code has to make sure that q_ring won't be borrowed.
-    #[deprecated(since = "0.8.0", note = "Use `complete_io_cmd_unified` instead")]
+    #[deprecated(
+        since = "0.5.0",
+        note = "Use `complete_io_cmd_unified` instead, removed in 0.6"
+    )]
     #[inline]
     pub fn complete_io_cmd_with_auto_buf_reg(
         &self,

--- a/src/io.rs
+++ b/src/io.rs
@@ -1048,6 +1048,8 @@ pub struct UblkQueue<'a> {
     io_cmd_buf: u64,
     //ops: Box<dyn UblkQueueImpl>,
     pub dev: &'a UblkDev,
+    /// Cached device flags from dev.dev_info.flags for performance optimization
+    dev_flags: u64,
     bufs: RefCell<Vec<*mut u8>>,
     state: RefCell<UblkQueueState>,
     /// Semaphore to coordinate buffer registrations
@@ -1218,6 +1220,7 @@ impl UblkQueue<'_> {
             q_depth: depth,
             io_cmd_buf: io_cmd_buf as u64,
             dev,
+            dev_flags: dev.dev_info.flags,
             state: RefCell::new(UblkQueueState {
                 cmd_inflight: 0,
                 state: 0,
@@ -1682,7 +1685,7 @@ impl UblkQueue<'_> {
         result: i32,
     ) -> Result<UblkUringOpFuture, UblkError> {
         // Validate buffer descriptor compatibility with device capabilities
-        buf_desc.validate_compatibility(self.dev.dev_info.flags)?;
+        buf_desc.validate_compatibility(self.dev_flags)?;
 
         // Dispatch to appropriate method based on buffer descriptor type
         let future = match buf_desc {
@@ -1975,8 +1978,7 @@ impl UblkQueue<'_> {
             };
 
             assert!(
-                ((self.dev.dev_info.flags & (crate::sys::UBLK_F_USER_COPY as u64)) != 0)
-                    == bufs.is_none()
+                ((self.dev_flags & (crate::sys::UBLK_F_USER_COPY as u64)) != 0) == bufs.is_none()
             );
             with_queue_ring_mut_internal!(|ring| {
                 self.queue_io_cmd(
@@ -2102,7 +2104,7 @@ impl UblkQueue<'_> {
             }
             BufDescList::AutoRegs(auto_reg_slice) => {
                 // AutoReg operations require UBLK_F_AUTO_BUF_REG
-                if (self.dev.dev_info.flags & sys::UBLK_F_AUTO_BUF_REG as u64) == 0 {
+                if (self.dev_flags & sys::UBLK_F_AUTO_BUF_REG as u64) == 0 {
                     return Err(UblkError::OtherError(-libc::ENOTSUP));
                 }
 
@@ -2288,7 +2290,7 @@ impl UblkQueue<'_> {
         res: Result<UblkIORes, UblkError>,
     ) -> Result<(), UblkError> {
         // Validate buffer descriptor compatibility with device capabilities
-        buf_desc.validate_compatibility(self.dev.dev_info.flags)?;
+        buf_desc.validate_compatibility(self.dev_flags)?;
 
         // Buffer validation for UBLK_DEV_F_MLOCK_IO_BUFFER
         self.validate_mlock_buffer_consistency(tag, &buf_desc)?;

--- a/src/io.rs
+++ b/src/io.rs
@@ -2397,6 +2397,10 @@ impl UblkQueue<'_> {
     }
 
     /// Return inflight IOs being handled by target code
+    #[deprecated(
+        since = "0.5.0",
+        note = "will be removed in 0.6.0 - it is easier for target code to count inflight IOs themselves"
+    )]
     #[inline]
     pub fn get_inflight_nr_io(&self) -> u32 {
         self.q_depth - self.state.borrow().get_nr_cmd_inflight()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,9 @@ bitflags! {
 macro_rules! ublk_internal_flags_all {
     () => {
         UblkFlags::UBLK_DEV_F_INTERNAL_0
-        | UblkFlags::UBLK_DEV_F_INTERNAL_1
-        | UblkFlags::UBLK_DEV_F_INTERNAL_2
-        | UblkFlags::UBLK_DEV_F_INTERNAL_3
+            | UblkFlags::UBLK_DEV_F_INTERNAL_1
+            | UblkFlags::UBLK_DEV_F_INTERNAL_2
+            | UblkFlags::UBLK_DEV_F_INTERNAL_3
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub mod ctrl_async;
 pub mod helpers;
 pub mod io;
 pub mod sys;
+#[cfg(test)]
+pub mod test_helpers;
 pub mod uring_async;
 
 // Re-export important types for unified buffer management

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,18 @@ bitflags! {
         /// It is required for ublk to be used as swap disk
         const UBLK_DEV_F_MLOCK_IO_BUFFER = 0b00100000;
 
+        /// disable IO statistics tracking: when set, the library will not
+        /// track queue state for performance optimization. This flag should
+        /// only be used with async/await code paths in case of zero copy,
+        /// user copy or UBLK_DEV_F_MLOCK_IO_BUFFER, in which there aren't
+        /// user io buffer pages for discarding, which depends on io counting.
+        ///
+        /// When this flag is set, enter_queue_idle() and exit_queue_idle()
+        /// are not supported, which means user IO buffer pages cannot be
+        /// discarded. However, this is not needed for zero copy, user copy,
+        /// and UBLK_DEV_F_MLOCK_IO_BUFFER configurations.
+        const UBLK_DEV_F_NO_IO_STAT = 0b01000000;
+
         const UBLK_DEV_F_INTERNAL_0 = 1_u32 << 31;
         const UBLK_DEV_F_INTERNAL_1 = 1_u32 << 30;
         const UBLK_DEV_F_INTERNAL_2 = 1_u32 << 29;

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,162 @@
+#![cfg(test)]
+
+//! Shared test utilities for async device testing
+//!
+//! This module provides common async test functions that can be shared
+//! between different test modules, particularly for testing ublk device
+//! creation and I/O operations.
+
+use crate::ctrl::UblkCtrlBuilder;
+use crate::io::{UblkDev, UblkQueue};
+use crate::uring_async::ublk_wake_task;
+use crate::{UblkError, UblkFlags};
+use std::rc::Rc;
+
+#[ctor::ctor]
+fn init_logger() {
+    let _ = env_logger::builder()
+        .format_target(false)
+        .format_timestamp(None)
+        .is_test(true)
+        .try_init();
+}
+
+/// Async I/O function for testing null device operations
+///
+/// This function simulates the I/O operations of a null device,
+/// accepting all writes and returning zeros for reads.
+pub(crate) async fn io_async_fn(tag: u16, q: &UblkQueue<'_>) -> Result<(), UblkError> {
+    use crate::helpers::IoBuf;
+    use crate::BufDesc;
+
+    let buf = IoBuf::<u8>::new(q.dev.dev_info.max_io_buf_bytes as usize);
+    let _buf = Some(buf);
+    let iod = q.get_iod(tag);
+    let buf_desc = BufDesc::Slice(_buf.as_ref().unwrap().as_slice());
+
+    // Submit initial prep command and handle any errors (including queue down)
+    // The IoBuf is automatically registered
+    q.submit_io_prep_cmd(tag, buf_desc.clone(), 0, _buf.as_ref())
+        .await?;
+
+    loop {
+        let res = (iod.nr_sectors << 9) as i32;
+        // Any error (including QueueIsDown) will break the loop
+        q.submit_io_commit_cmd(tag, buf_desc.clone(), res).await?;
+    }
+}
+
+/// Queue async function for spawning I/O tasks
+///
+/// This function creates async tasks for each tag in the queue depth,
+/// simulating concurrent I/O operations.
+pub(crate) fn q_async_fn<'a>(
+    exe: &smol::LocalExecutor<'a>,
+    q_rc: &Rc<UblkQueue<'a>>,
+    depth: u16,
+    f_vec: &mut Vec<smol::Task<()>>,
+) {
+    for tag in 0..depth as u16 {
+        let q = q_rc.clone();
+        f_vec.push(exe.spawn(async move {
+            if let Err(e) = io_async_fn(tag, &q).await {
+                match e {
+                    UblkError::QueueIsDown => {
+                        // Queue down is expected during shutdown, don't log as error
+                    }
+                    _ => {
+                        log::debug!("io_async_fn failed for tag {}: {}", tag, e);
+                    }
+                }
+            }
+        }));
+    }
+}
+
+/// Device handler for async testing
+///
+/// Creates and manages a test ublk device with the specified flags.
+/// This is useful for testing different device configurations.
+pub(crate) async fn device_handler_async(dev_flags: UblkFlags) -> Result<(), UblkError> {
+    let ctrl = UblkCtrlBuilder::default()
+        .name("test_async")
+        .dev_flags(dev_flags)
+        .depth(8)
+        .build_async()
+        .await
+        .unwrap();
+
+    let tgt_init = |dev: &mut UblkDev| {
+        dev.set_default_params(250_u64 << 30);
+        Ok(())
+    };
+    // Use the new async method directly
+    let dev_arc = &std::sync::Arc::new(UblkDev::new_async(ctrl.get_name(), tgt_init, &ctrl)?);
+    let dev = dev_arc.clone();
+    assert!(dev_arc.dev_info.nr_hw_queues == 1);
+
+    // Todo: support to handle multiple queues in one thread context
+    let qh = std::thread::spawn(move || {
+        let q_rc = Rc::new(UblkQueue::new(0 as u16, &dev).unwrap());
+        let q = q_rc.clone();
+        let exe = smol::LocalExecutor::new();
+        let mut f_vec: Vec<smol::Task<()>> = Vec::new();
+
+        if dev_flags.contains(UblkFlags::UBLK_DEV_F_MLOCK_IO_BUFFER) {
+            q.mark_mlock_failed();
+        }
+
+        q_async_fn(&exe, &q, dev.dev_info.queue_depth as u16, &mut f_vec);
+
+        crate::uring_async::ublk_wait_and_handle_ios(&exe, &q_rc);
+        smol::block_on(exe.run(async { futures::future::join_all(f_vec).await }));
+    });
+
+    // Avoid to leak device
+    if let Err(_) = ctrl.start_dev_async(dev_arc).await {
+        log::warn!("device_handler_async: fail to start device(async)");
+    }
+
+    ctrl.dump_async().await?;
+    ctrl.kill_dev_async().await?;
+
+    // async/await needs to delete device by itself, otherwise we
+    // may hang in Drop() of UblkCtrlInner.
+    ctrl.del_dev_async_await().await?;
+
+    qh.join()
+        .unwrap_or_else(|_| eprintln!("dev-{} join queue thread failed", dev_arc.dev_info.dev_id));
+    Ok(())
+}
+
+/// Block on all tasks in the executor until they are finished
+///
+/// Utility function for managing task execution in tests.
+pub(crate) fn ublk_join_tasks<T>(
+    exe: &smol::LocalExecutor,
+    tasks: Vec<smol::Task<T>>,
+) -> Result<(), UblkError> {
+    use io_uring::{squeue, IoUring};
+    loop {
+        // Check if all tasks are finished
+        if tasks.iter().all(|task| task.is_finished()) {
+            break;
+        }
+
+        // Drive the executor to make progress on tasks
+        while exe.try_tick() {}
+
+        // Handle control uring events
+        let entry =
+            crate::ctrl::with_ctrl_ring_mut_internal!(|r: &mut IoUring<squeue::Entry128>| {
+                match r.submit_and_wait(0) {
+                    Err(_) => None,
+                    _ => r.completion().next(),
+                }
+            });
+        if let Some(cqe) = entry {
+            ublk_wake_task(cqe.user_data(), &cqe);
+        }
+    }
+    Ok(())
+}

--- a/src/uring_async.rs
+++ b/src/uring_async.rs
@@ -174,7 +174,8 @@ pub fn ublk_run_ctrl_task<T>(
     task: &smol::Task<T>,
 ) -> Result<(), UblkError> {
     let mut pr: IoUring<squeue::Entry, cqueue::Entry> = IoUring::builder().build(4)?;
-    let ctrl_fd = crate::ctrl::with_ctrl_ring_internal!(|ring: &IoUring<squeue::Entry128>| ring.as_raw_fd());
+    let ctrl_fd =
+        crate::ctrl::with_ctrl_ring_internal!(|ring: &IoUring<squeue::Entry128>| ring.as_raw_fd());
     let q_fd = q.as_raw_fd();
     let mut poll_q = true;
     let mut poll_ctrl = true;
@@ -211,7 +212,10 @@ pub fn ublk_run_ctrl_task<T>(
         }
 
         ublk_process_queue_io(exe, q, 0)?;
-        let entry = crate::ctrl::with_ctrl_ring_mut_internal!(|ring: &mut IoUring<squeue::Entry128>| ublk_try_reap_cqe(ring, 0));
+        let entry =
+            crate::ctrl::with_ctrl_ring_mut_internal!(|ring: &mut IoUring<squeue::Entry128>| {
+                ublk_try_reap_cqe(ring, 0)
+            });
         if let Some(cqe) = entry {
             ublk_wake_task(cqe.user_data(), &cqe);
             while exe.try_tick() {}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -16,15 +16,6 @@ mod integration {
     use std::rc::Rc;
     use std::sync::{Arc, Mutex};
 
-    #[ctor::ctor]
-    fn init_logger() {
-        let _ = env_logger::builder()
-            .format_target(false)
-            .format_timestamp(None)
-            .is_test(true)
-            .try_init();
-    }
-
     fn run_ublk_disk_sanity_test(ctrl: &UblkCtrl, dev_flags: UblkFlags) {
         use std::os::unix::fs::PermissionsExt;
         let dev_path = ctrl.get_cdev_path();

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -261,8 +261,7 @@ mod integration {
                 f_vec.push(exe.spawn(async move {
                     match test_io_task(&q, tag, &__dev_data).await {
                         Err(UblkError::QueueIsDown) | Ok(_) => {}
-                        Err(e) =>
-                            log::error!("test_io_task failed for tag {}: {}", tag, e)
+                        Err(e) => log::error!("test_io_task failed for tag {}: {}", tag, e),
                     }
                 }));
             }
@@ -374,8 +373,9 @@ mod integration {
                 f_vec.push(exe.spawn(async move {
                     match test_auto_reg_io_task(&q, tag, depth, bad_buf_idx, fallback).await {
                         Err(UblkError::QueueIsDown) | Ok(_) => {}
-                        Err(e) =>
-                            log::error!("test_auto_reg_io_task failed for tag {}: {}", tag, e),
+                        Err(e) => {
+                            log::error!("test_auto_reg_io_task failed for tag {}: {}", tag, e)
+                        }
                     }
                 }));
             }
@@ -550,8 +550,7 @@ mod integration {
                 f_vec.push(exe.spawn(async move {
                     match test_ramdisk_io_task(&q, tag, ramdisk_addr, mlock_enabled).await {
                         Err(UblkError::QueueIsDown) | Ok(_) => {}
-                        Err(e) =>
-                            log::error!("test_ramdisk_io_task failed for tag {}: {}", tag, e)
+                        Err(e) => log::error!("test_ramdisk_io_task failed for tag {}: {}", tag, e),
                     }
                 }));
             }


### PR DESCRIPTION
- deprecate uring_op(), uring_op_mut() and get_inflight_nr_io()
- support UblkFlags::UBLK_DEV_F_NO_IO_STAT
- optimize: cache dev.dev_info.flags in UblkQueue for performance
- simplify wait_and_handle_io using flush_and_wake_io_tasks